### PR TITLE
Fix Bug: virtio devices sometimes stuck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ export KDIR
 build_path := target/$(RUSTC_TARGET)/$(MODE)
 hvisor_elf := $(build_path)/hvisor
 hvisor_bin := $(build_path)/hvisor.bin
-daemon_elf := tools/hvisor
 image_dir  := images/$(ARCH)
 
 # Features based on STATS
@@ -45,7 +44,7 @@ ifeq ($(MODE), release)
 endif
 
 # Targets
-.PHONY: all elf disa run gdb monitor clean tools rootfs transfer
+.PHONY: all elf disa run gdb monitor clean tools rootfs
 all: $(hvisor_bin)
 
 elf:
@@ -59,14 +58,10 @@ tools:
 	make -C tools && \
 	make -C driver
 
-transfer:
-	~/trans_file.sh ./tools/hvisor 
-	~/trans_file.sh ./driver/main.ko 
-
-run: all tools transfer
+run: all
 	$(QEMU) $(QEMU_ARGS)
 
-gdb: all tools transfer
+gdb: all
 	$(QEMU) $(QEMU_ARGS) -s -S
 
 show-features:
@@ -75,9 +70,8 @@ show-features:
 monitor:
 	gdb-multiarch \
 		-ex 'file $(hvisor_elf)' \
-		-ex 'file $(daemon_elf)' \
 		-ex 'set arch $(GDB_ARCH)' \
-		-ex 'target remote:1234' 
+		-ex 'target remote:1234' \
 
 clean:
 	cargo clean

--- a/driver/hvisor.h
+++ b/driver/hvisor.h
@@ -44,7 +44,7 @@ struct device_res {
     __u32 irq_id;
 };
 
-struct hvisor_device_region {
+struct virtio_bridge {
 	__u32 req_front;
 	__u32 req_rear;
     __u32 res_front;
@@ -61,42 +61,40 @@ struct hvisor_device_region {
 
 #define HVISOR_INIT_VIRTIO  _IO(1, 0) // virtio device init
 #define HVISOR_GET_TASK _IO(1, 1)	
-#define HVISOR_FINISH _IO(1, 2)		  // finish one virtio req	
+#define HVISOR_FINISH_REQ _IO(1, 2)		  // finish one virtio req	
 #define HVISOR_ZONE_START _IOW(1, 3, struct hvisor_zone_load*)
 #define HVISOR_ZONE_SHUTDOWN _IOW(1, 4, __u64)
 // hypercall
-#define HVISOR_CALL_NUM_RESULT "x0"
-#define HVISOR_CALL_ARG1       "x1"
-#define HVISOR_CALL_INS        "hvc #0x4a48"
+#define HVISOR_CALL_HVC        "hvc #0x4856"
 
-#define HVISOR_HC_INIT_VIRTIO 9
-#define HVISOR_HC_FINISH_REQ 10
-#define HVISOR_HC_START_ZONE 11
-#define HVISOR_HC_SHUTDOWN_ZONE 12
+#define HVISOR_HC_INIT_VIRTIO 0
+#define HVISOR_HC_FINISH_REQ 1
+#define HVISOR_HC_START_ZONE 2
+#define HVISOR_HC_SHUTDOWN_ZONE 3
 
-static inline __u64 hvisor_call(__u64 num)
+static inline __u64 hvisor_call(__u64 code)
 {
-	register __u64 num_result asm(HVISOR_CALL_NUM_RESULT) = num;
+	register __u64 code_result asm("x0") = code;
 
 	asm volatile(
-		HVISOR_CALL_INS
-		: "=r" (num_result)
-		: "r" (num_result)
+		HVISOR_CALL_HVC
+		: "=r" (code_result)
+		: "r" (code_result)
 		: "memory");
-	return num_result;
+	return code_result;
 }
 
-static inline __u64 hvisor_call_arg1(__u64 num, __u64 arg1)
+static inline __u64 hvisor_call_arg1(__u64 code, __u64 arg0)
 {
-	register __u64 num_result asm(HVISOR_CALL_NUM_RESULT) = num;
-	register __u64 __arg1 asm(HVISOR_CALL_ARG1) = arg1;
+	register __u64 code_result asm("x0") = code;
+	register __u64 __arg0 asm("x1") = arg0;
 
 	asm volatile(
-		HVISOR_CALL_INS
-		: "=r" (num_result)
-		: "r" (num_result), "r" (__arg1)
+		HVISOR_CALL_HVC
+		: "=r" (code_result)
+		: "r" (code_result), "r" (__arg0)
 		: "memory");
-	return num_result;
+	return code_result;
 }
 
 

--- a/images/aarch64/devicetree/linux1.dts
+++ b/images/aarch64/devicetree/linux1.dts
@@ -147,7 +147,7 @@
 		stdout-path = "/pl011@9000000";
 	};
 
-	vm_service {
+	hvisor_device {
 		compatible = "hvisor";
 		interrupt-parent = <0x01>;
 		interrupts = <0x00 0x20 0x01>;

--- a/src/arch/aarch64/cpu.rs
+++ b/src/arch/aarch64/cpu.rs
@@ -121,6 +121,7 @@ impl ArchCpu {
         write_sysreg!(VBAR_EL1, 0);
 
         /* wipe timer registers */
+		write_sysreg!(CNTVOFF_EL2, 0);
         write_sysreg!(CNTP_CTL_EL0, 0);
         write_sysreg!(CNTP_CVAL_EL0, 0);
         write_sysreg!(CNTP_TVAL_EL0, 0);

--- a/src/arch/aarch64/zone.rs
+++ b/src/arch/aarch64/zone.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{fence, Ordering};
 use alloc::vec::Vec;
 
 use crate::{
-    device::virtio_trampoline::{mmio_virtio_handler, HVISOR_DEVICE},
+    device::virtio_trampoline::{mmio_virtio_handler, VIRTIO_BRIDGE},
     error::HvResult,
     memory::{
         addr::align_up, mmio_generic_handler, GuestPhysAddr, HostPhysAddr, MemFlags, MemoryRegion,
@@ -41,7 +41,7 @@ impl Zone {
         // probe virtio mmio device
         {
             let mut mapped_virtio = Vec::new();
-            let dev = HVISOR_DEVICE.lock();
+            let dev = VIRTIO_BRIDGE.lock();
             let region = if dev.is_enable {
                 Some(dev.immut_region())
             } else {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,7 +2,7 @@ CC = aarch64-none-linux-gnu-gcc
 CFLAGS = -Wall -Wextra -DLOG_USE_COLOR
 objects := $(wildcard *.c)
 all: 
-	$(CC) $(CFLAGS) -o hvisor $(objects) -I../driver/ -I./includes/ -lpthread
+	$(CC) $(CFLAGS) -g -o hvisor $(objects) -I../driver/ -I./includes/ -lpthread
 
 clean:
 	rm hvisor

--- a/tools/event_monitor.c
+++ b/tools/event_monitor.c
@@ -29,20 +29,21 @@ struct hvisor_event *add_event(int fd, int epoll_type,
         void (*handler)(int, int, void *), void *param)
 {
     struct hvisor_event *hevent;
-    struct epoll_event ee;
+    struct epoll_event eevent;
     int ret;
     if (fd < 0 || handler == NULL)
         return NULL;
     hevent = calloc(1, sizeof(struct hvisor_event));
     if (hevent == NULL)
         return NULL;
+	hevent->handler = handler;
+    hevent->param = param;
     hevent->fd = fd;
     hevent->epoll_type = epoll_type;
-    hevent->handler = handler;
-    hevent->param = param;
-    ee.events = epoll_type;
-    ee.data.ptr = hevent;
-    ret = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, hevent->fd, &ee);
+
+    eevent.events = epoll_type;
+    eevent.data.ptr = hevent;
+    ret = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, hevent->fd, &eevent);
     if (ret < 0) {
         log_error("epoll_ctl failed, errno is %d", errno);
         free(hevent);

--- a/tools/includes/virtio_blk.h
+++ b/tools/includes/virtio_blk.h
@@ -17,10 +17,6 @@
 typedef struct virtio_blk_config BlkConfig;
 typedef struct virtio_blk_outhdr BlkReqHead;
 
-enum blkop {
-	BLK_READ,
-	BLK_WRITE
-};
 // A request needed to process by blk thread.
 struct blkp_req {
 	TAILQ_ENTRY(blkp_req) link;
@@ -34,12 +30,12 @@ struct blkp_req {
 typedef struct virtio_blk_dev {
     BlkConfig config;
     int img_fd;
-	// describe the thread executes read and write.
+	// describe the worker thread that executes read, write and ioctl.
 	pthread_t tid;
 	pthread_mutex_t mtx;
 	pthread_cond_t cond;
 	TAILQ_HEAD(, blkp_req) procq;
-	int closing;
+	int close;
 } BlkDev;
 
 BlkDev *init_blk_dev(VirtIODevice *vdev, uint64_t bsize, int img_fd);

--- a/tools/includes/virtio_blk.h
+++ b/tools/includes/virtio_blk.h
@@ -12,6 +12,7 @@
 // A blk sector size
 #define SECTOR_BSIZE 512
 
+// VIRTIO_RING_F_INDIRECT_DESC and VIRTIO_RING_F_EVENT_IDX are supported, for some reason we cancel them.
 #define BLK_SUPPORTED_FEATURES ( (1ULL << VIRTIO_BLK_F_SEG_MAX) | (1ULL << VIRTIO_BLK_F_SIZE_MAX) | (1ULL << VIRTIO_F_VERSION_1))
 
 typedef struct virtio_blk_config BlkConfig;

--- a/tools/includes/virtio_net.h
+++ b/tools/includes/virtio_net.h
@@ -21,7 +21,7 @@ typedef struct virtio_net_hdr_v1 NetHdr;
 typedef struct virtio_net_dev {
     NetConfig config;
     int tapfd;
-    int rx_ready;   // If rxq has available empty buffers.
+    int rx_ready;   
     struct hvisor_event *event;
 } NetDev;
 

--- a/tools/includes/virtio_net.h
+++ b/tools/includes/virtio_net.h
@@ -12,7 +12,7 @@
 #define NET_MAX_QUEUES  2
 
 #define VIRTQUEUE_NET_MAX_SIZE 256
-
+// VIRTIO_RING_F_INDIRECT_DESC and VIRTIO_RING_F_EVENT_IDX are supported, for some reason we cancel them.
 #define NET_SUPPORTED_FEATURES ( (1ULL << VIRTIO_F_VERSION_1) | (1ULL << VIRTIO_NET_F_MAC) | (1ULL << VIRTIO_NET_F_STATUS) )
 
 typedef struct virtio_net_config NetConfig;

--- a/tools/log.c
+++ b/tools/log.c
@@ -140,16 +140,17 @@ static void init_event(log_Event *ev, void *udata) {
 
 
 void log_log(int with_enter, int level, const char *file, int line, const char *fmt, ...) {
+  if(L.quiet || level < L.level) {
+	return ;
+  }
+
   log_Event ev = {
     .fmt   = fmt,
     .file  = file,
     .line  = line,
     .level = level,
   };
-
-  if(L.quiet || level < L.level) {
-	return ;
-  }
+  
   lock();
 
   if (!L.quiet && level >= L.level) {

--- a/tools/virtio_blk.c
+++ b/tools/virtio_blk.c
@@ -19,7 +19,6 @@ static void complete_block_operation(BlkDev *dev, struct blkp_req *req, VirtQueu
         log_error("virt blk err, num is %d", err);
     }
     update_used_ring(vq, req->idx, written_len + 1);
-	// 注释了就不能正常工作了，不知道为什么
     pthread_mutex_lock(&dev->mtx);
 	is_empty = TAILQ_EMPTY(&dev->procq);
 	pthread_mutex_unlock(&dev->mtx);


### PR DESCRIPTION
1. Fixing an issue where virtio devices would occasionally become stuck and stop functioning.
2. Improving code naming conventions.
3. Adding a feature: VIRTIO_RING_F_INDIRECT_DESC. However, it is currently disabled due to its significant memory usage.