### PR TITLE
Support sip smc and maintenance interrupt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ modules.order
 driver/main.ko
 .gdb_history
 .vscode-ctags
+Image*
+*.ext4
+*.qcow2
+*.dtb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,12 +67,14 @@
 	// Prevent "can't find crate for `test`" error on no_std
 	// Ref: https://github.com/rust-lang/vscode-rust/issues/729
 	// For vscode-rust plugin users:
+	"rust.target": "aarch64-unknown-none",
 	// "rust.target": "riscv64gc-unknown-none-elf",
-	"rust.target": "loongarch64-unknown-none",
+	// "rust.target": "loongarch64-unknown-none",
 	"rust.all_targets": false,
 	// For Rust Analyzer plugin users:
+	"rust-analyzer.cargo.target": "aarch64-unknown-none",
 	// "rust-analyzer.cargo.target": "riscv64gc-unknown-none-elf",
-	"rust-analyzer.cargo.target": "loongarch64-unknown-none",
+	// "rust-analyzer.cargo.target": "loongarch64-unknown-none",
 	"rust-analyzer.checkOnSave.allTargets": false,
 	// "rust-analyzer.cargo.features": [
 	//     "board_qemu"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Basic settings
-ARCH ?= loongarch64
-LOG ?= debug
+ARCH ?= aarch64
+LOG ?= info
 STATS ?= off
 PORT ?= 2333
 MODE ?= debug
 OBJCOPY ?= rust-objcopy --binary-architecture=$(ARCH)
 KDIR ?= ../../linux
-FEATURES ?= platform_qemu
+FEATURES ?= platform_imx8mp
 
 ifeq ($(ARCH),aarch64)
     RUSTC_TARGET := aarch64-unknown-none

--- a/src/arch/aarch64/cpu.rs
+++ b/src/arch/aarch64/cpu.rs
@@ -1,11 +1,8 @@
 use crate::{
-    arch::{mm::new_s2_memory_set, sysreg::write_sysreg},
-    consts::{PAGE_SIZE, PER_CPU_ARRAY_PTR, PER_CPU_SIZE},
-    memory::{
+    arch::{mm::new_s2_memory_set, sysreg::write_sysreg}, consts::{PAGE_SIZE, PER_CPU_ARRAY_PTR, PER_CPU_SIZE}, device::irqchip::gicv3::{gicr::{GICR_ICACTIVER, GICR_ICENABLER, GICR_ISENABLER, GICR_SGI_BASE}, host_gicr_base, MAINTENACE_INTERRUPT}, memory::{
         addr::PHYS_VIRT_OFFSET, mm::PARKING_MEMORY_SET, GuestPhysAddr, HostPhysAddr, MemFlags,
         MemoryRegion, VirtAddr, PARKING_INST_PAGE,
-    },
-    percpu::this_cpu_data,
+    }, percpu::this_cpu_data
 };
 use aarch64_cpu::registers::{
     Readable, Writeable, ELR_EL2, HCR_EL2, MPIDR_EL1, SCTLR_EL1, SPSR_EL2, VTCR_EL2,
@@ -62,6 +59,13 @@ impl ArchCpu {
         regs.usr[0] = dtb as _; // dtb addr
         self.reset_vm_regs();
         self.activate_vmm();
+        // unsafe {
+        //     let base = host_gicr_base(this_cpu_id()) + GICR_SGI_BASE;
+        //     let gicr_isenabler0 = (base + GICR_ISENABLER) as *mut u32;
+        //     gicr_isenabler0.write_volatile(0xffff | 1 << MAINTENACE_INTERRUPT);
+        //     let gicr_icenabler0 = (base + GICR_ICENABLER) as *mut u32;
+        //     gicr_icenabler0.write_volatile(0xffff0000 & !(1 << MAINTENACE_INTERRUPT));
+        // }
     }
 
     fn activate_vmm(&self) {

--- a/src/arch/aarch64/sysreg.rs
+++ b/src/arch/aarch64/sysreg.rs
@@ -19,6 +19,7 @@ macro_rules! read_sysreg {
         }
     }
 }
+use psci::smccc::smc64;
 pub(crate) use read_sysreg;
 
 /// Writes the given value to the given aarch64 system register.
@@ -44,6 +45,11 @@ macro_rules! smc_arg1 {
     }};
 }
 pub(crate) use smc_arg1;
+
+pub fn smc_call(function: u64, args: &[u64]) -> u64 {
+    let args: [u64; 17] = args.try_into().expect("args length should be 17");
+    smc64(function as _, args)[0]
+}
 // macro_rules! read_lrreg {
 //     ($lr:expr) => {
 //         {

--- a/src/platform/imx8mp_aarch64.rs
+++ b/src/platform/imx8mp_aarch64.rs
@@ -25,7 +25,26 @@ pub const ROOT_ZONE_MEMORY_REGIONS: [HvConfigMemoryRegion; 3] = [
         physical_start: 0x30800000,
         virtual_start: 0x30800000,
         size: 0x400000,
-    }, // bus@30800000
+    }, 
+    // HvConfigMemoryRegion {
+    //     mem_type: MEM_TYPE_IO,
+    //     physical_start: 0x38000000,
+    //     virtual_start: 0x38000000,
+    //     size: 0x8000,
+    // },
+    // HvConfigMemoryRegion {
+    //     mem_type: MEM_TYPE_IO,
+    //     physical_start: 0x38008000,
+    //     virtual_start: 0x38008000,
+    //     size: 0x8000,
+    // },
+    // HvConfigMemoryRegion {
+    //     mem_type: MEM_TYPE_IO,
+    //     physical_start: 0x38500000,
+    //     virtual_start: 0x38500000,
+    //     size: 0x20000,
+    // }
+    // bus@30800000
        // HvConfigMemoryRegion {
        //     mem_type: MEM_TYPE_IO,
        //     physical_start: 0x30890000,


### PR DESCRIPTION
The pr solve two problems:
1. support sip smc so that vm on hvisor can use GPU on NXP. All sip smc will be submitted to uboot.
2. support maintenance interrupt so that when list registers overflow, hvisor can save pending interrupts and inject them when list registers are available.