### PR TITLE
fix(images): edit zone config to resolve boot bug in zone1,2

### DIFF
--- a/images/aarch64/devicetree/linux1.dts
+++ b/images/aarch64/devicetree/linux1.dts
@@ -189,7 +189,7 @@
 		stdout-path = "/pl011@9000000";
 	};
 
-	hvisor_device {
+	hvisor_virtio_device {
 		compatible = "hvisor";
 		interrupt-parent = <0x01>;
 		interrupts = <0x00 0x20 0x01>;

--- a/images/aarch64/devicetree/linux2.dts
+++ b/images/aarch64/devicetree/linux2.dts
@@ -17,14 +17,6 @@
 			compatible = "arm,cortex-a57";
 			device_type = "cpu";
 		};
-
-		cpu@3 {
-			reg = <0x03>;
-			enable-method = "psci";
-			compatible = "arm,cortex-a57";
-			device_type = "cpu";
-		};
-
 	};
 
 	psci {

--- a/images/aarch64/devicetree/linux2.json
+++ b/images/aarch64/devicetree/linux2.json
@@ -24,6 +24,7 @@
         }
     ],
     "interrupts": [75, 76, 78, 35, 36, 37, 38],
+    "ivc_configs": [],
     "kernel_filepath": "./Image",
     "dtb_filepath": "./linux2.dtb",
     "kernel_load_paddr": "0x50400000",

--- a/images/aarch64/devicetree/linux3.json
+++ b/images/aarch64/devicetree/linux3.json
@@ -24,6 +24,7 @@
         }
     ],
     "interrupts": [75, 76, 78],
+    "ivc_configs": [],
     "kernel_filepath": "./Image",
     "dtb_filepath": "./linux3.dtb",
     "kernel_load_paddr": "0x80400000",

--- a/images/aarch64/devicetree/virtio_cfg2.json
+++ b/images/aarch64/devicetree/virtio_cfg2.json
@@ -2,7 +2,13 @@
     "zones": [
         {
             "id": 1,
-            "memory_region": ["0x50000000", "0x30000000"],
+            "memory_region": [
+                {
+                    "zone0_ipa": "0x50000000",
+                    "zonex_ipa": "0x50000000",
+                    "size": "0x30000000"
+                }
+            ],
             "devices": [
                     {
                         "type": "blk",

--- a/images/aarch64/devicetree/virtio_cfg3.json
+++ b/images/aarch64/devicetree/virtio_cfg3.json
@@ -2,7 +2,13 @@
     "zones": [
         {
             "id": 2,
-            "memory_region": ["0x80000000", "0x10000000"],
+            "memory_region": [
+                {
+                    "zone0_ipa": "0x80000000",
+                    "zonex_ipa": "0x80000000",
+                    "size": "0x10000000"
+                }
+            ],
             "devices": [
                     {
                         "type": "blk",


### PR DESCRIPTION
By modifying the dtb, linux.json, and virtio_cfg.json files in the repository, resolve the issue of being unable to boot non-root linux using the configuration files from the repository.