### PR TITLE
add riscv64 support for branch hvisor-dev

### DIFF
--- a/hvisor-dev/platform/riscv64/qemu/configs/zone1-linux.json
+++ b/hvisor-dev/platform/riscv64/qemu/configs/zone1-linux.json
@@ -1,0 +1,37 @@
+{
+    "arch": "riscv",
+    "name": "linux2",
+    "zone_id": 1,
+    "cpus": [3],
+    "memory_regions": [
+        {
+            "type": "ram",
+            "physical_start": "0x83000000",
+            "virtual_start":  "0x83000000",
+            "size": "0x0C000000"
+        },
+        {
+            "type": "io",
+            "physical_start": "0x10007000",
+            "virtual_start":  "0x10007000",
+            "size": "0x1000"
+        },
+        {
+            "type": "io",
+            "physical_start": "0x10006000",
+            "virtual_start":  "0x10006000",
+            "size": "0x1000"
+        }
+    ],
+    "interrupts": [6,7],
+    "kernel_filepath": "./Image",
+    "dtb_filepath": "./linux2.dtb",
+    "kernel_load_paddr": "0x84000000",
+    "dtb_load_paddr":    "0x83000000",
+    "entry_point":       "0x84000000",
+    "arch_config": {
+        "plic_base": "0xc000000",
+        "plic_size": "0x4000000"
+    },
+    "ivc_configs": []
+}

--- a/hvisor-dev/platform/riscv64/qemu/dts/zone0.dts
+++ b/hvisor-dev/platform/riscv64/qemu/dts/zone0.dts
@@ -1,0 +1,177 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+
+	cpus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		timebase-frequency = <10000000>;
+
+		cpu@0 {
+			device_type = "cpu";
+			reg = <0x0>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa = "rv64imafdcsu_sstc";
+			mmu-type = "riscv,sv39";
+
+			cpu0_intc: interrupt-controller {
+				#interrupt-cells = <0x1>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+			};
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			reg = <0x1>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa = "rv64imafdcsu_sstc";
+			mmu-type = "riscv,sv39";
+
+			cpu1_intc: interrupt-controller {
+				#interrupt-cells = <0x1>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+			};
+		};
+		cpu@2 {
+			device_type = "cpu";
+			reg = <0x2>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa = "rv64imafdcsu_sstc";
+			mmu-type = "riscv,sv39";
+
+			cpu2_intc: interrupt-controller {
+				#interrupt-cells = <0x1>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+			};
+		};
+
+	};
+
+	memory@83000000 {
+		device_type = "memory";
+		reg = <0x0 0x83000000 0x0 0x1D000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		ranges;
+
+		nonroot@0x83000000 {
+			no-map;
+			reg = <0x00 0x83000000 0x00 0x0C000000>;
+		};
+
+		dtbfile@0x8f000000 {
+			no-map;
+			reg = <0x00 0x8f000000 0x00 0x01000000>;
+		};
+	};
+
+	soc{
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+		plic: interrupt-controller@c000000 {
+			phandle = <0x03>;
+			riscv,ndev = <0x5f>;
+			reg = <0x00 0xc000000 0x00 0x600000>;
+			interrupts-extended = <
+				&cpu0_intc 11 &cpu0_intc 9 
+				&cpu1_intc 11 &cpu1_intc 9 
+				&cpu2_intc 11 &cpu2_intc 9
+			>;
+			interrupt-controller;
+			compatible = "riscv,plic0";
+			#interrupt-cells = <0x1>;
+		};
+		uart@10000000 {
+			interrupts = <0x0a>;
+			interrupt-parent = <&plic>;
+			clock-frequency = "\08@";
+			reg = <0x00 0x10000000 0x00 0x100>;
+			compatible = "ns16550a";
+		};
+		pci@30000000 {
+			interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x03 0x20 0x00 0x00 0x00 0x02 0x03 0x21 0x00 0x00 0x00 0x03 0x03 0x22 0x00 0x00 0x00 0x04 0x03 0x23 0x800 0x00 0x00 0x01 0x03 0x21 0x800 0x00 0x00 0x02 0x03 0x22 0x800 0x00 0x00 0x03 0x03 0x23 0x800 0x00 0x00 0x04 0x03 0x20 0x1000 0x00 0x00 0x01 0x03 0x22 0x1000 0x00 0x00 0x02 0x03 0x23 0x1000 0x00 0x00 0x03 0x03 0x20 0x1000 0x00 0x00 0x04 0x03 0x21 0x1800 0x00 0x00 0x01 0x03 0x23 0x1800 0x00 0x00 0x02 0x03 0x20 0x1800 0x00 0x00 0x03 0x03 0x21 0x1800 0x00 0x00 0x04 0x03 0x22>;
+			ranges = <0x1000000 0x00 0x00 0x00 0x3000000 0x00 0x10000 0x2000000 0x00 0x40000000 0x00 0x40000000 0x00 0x40000000 0x3000000 0x04 0x00 0x04 0x00 0x04 0x00>;
+			reg = <0x00 0x30000000 0x00 0x10000000>;
+			dma-coherent;
+			bus-range = <0x00 0xff>;
+			linux,pci-domain = <0x00>;
+			device_type = "pci";
+			compatible = "pci-host-ecam-generic";
+			#size-cells = <0x02>;
+			#interrupt-cells = <0x01>;
+			#address-cells = <0x03>;
+		};
+
+		virtio_mmio@10008000 {
+		interrupts = <0x8>;
+		interrupt-parent = <&plic>;
+		reg = <0x0 0x10008000 0x0 0x1000>;
+		compatible = "virtio,mmio";
+		};
+		//	virtio_mmio@10007000 {
+		//		interrupts = <0x7>;
+		//		interrupt-parent = <&plic>;
+		//		reg = <0x0 0x10007000 0x0 0x1000>;
+		//		compatible = "virtio,mmio";
+		//	};
+		// virtio_mmio@10006000 {
+		// 	interrupts = <0x6>;
+		// 	interrupt-parent = <&plic>;
+		// 	reg = <0x0 0x10006000 0x0 0x1000>;
+		// 	compatible = "virtio,mmio";
+		// };
+
+		virtio_mmio@10005000 {
+			interrupts = <0x5>;
+			interrupt-parent = <&plic>;
+			reg = <0x0 0x10005000 0x0 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10004000 {
+			interrupts = <0x4>;
+			interrupt-parent = <&plic>;
+			reg = <0x0 0x10004000 0x0 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10003000 {
+			interrupts = <0x3>;
+			interrupt-parent = <&plic>;
+			reg = <0x0 0x10003000 0x0 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10002000 {
+			interrupts = <0x2>;
+			interrupt-parent = <&plic>;
+			reg = <0x0 0x10002000 0x0 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10001000 {
+			interrupts = <0x1>;
+			interrupt-parent = <&plic>;
+			reg = <0x0 0x10001000 0x0 0x1000>;
+			compatible = "virtio,mmio";
+		};
+	};
+	chosen {
+		bootargs = "root=/dev/vda rw earlycon console=ttyS0";
+	};
+
+};

--- a/hvisor-dev/platform/riscv64/qemu/dts/zone1-linux.dts
+++ b/hvisor-dev/platform/riscv64/qemu/dts/zone1-linux.dts
@@ -1,0 +1,107 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+
+	cpus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		timebase-frequency = <10000000>;
+		cpu@3 {
+			device_type = "cpu";
+			reg = <0x3>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa = "rv64imafdcsu_sstc";
+			mmu-type = "riscv,sv39";
+
+			cpu3_intc: interrupt-controller {
+				#interrupt-cells = <0x1>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+			};
+		};
+
+	};
+
+	memory@84000000 {
+		device_type = "memory";
+		reg = <0x0 0x84000000 0x0 0x08000000>;
+	};
+soc{
+			#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+	plic: interrupt-controller@c000000 {
+		riscv,ndev = <60>;
+		reg = <0x0 0xc000000 0x0 0x4000000>;
+		interrupts-extended = <
+			&cpu3_intc 11 &cpu3_intc 9
+		>;
+		interrupt-controller;
+		compatible = "riscv,plic0";
+		#interrupt-cells = <0x1>;
+	};
+
+//		virtio_mmio@10008000 {
+//		interrupts = <0x8>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10008000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+	virtio_mmio@10007000 {
+		interrupts = <0x7>;
+		interrupt-parent = <&plic>;
+		reg = <0x0 0x10007000 0x0 0x1000>;
+		compatible = "virtio,mmio";
+	};
+	virtio_mmio@10006000 {
+		interrupts = <0x6>;
+		interrupt-parent = <&plic>;
+		reg = <0x0 0x10006000 0x0 0x1000>;
+		compatible = "virtio,mmio";
+	};
+//
+//	virtio_mmio@10005000 {
+//		interrupts = <0x5>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10005000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+//
+//	virtio_mmio@10004000 {
+//		interrupts = <0x4>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10004000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+//
+//	virtio_mmio@10003000 {
+//		interrupts = <0x3>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10003000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+//
+//	virtio_mmio@10002000 {
+//		interrupts = <0x2>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10002000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+//
+//	virtio_mmio@10001000 {
+//		interrupts = <0x1>;
+//		interrupt-parent = <&plic>;
+//		reg = <0x0 0x10001000 0x0 0x1000>;
+//		compatible = "virtio,mmio";
+//	};
+
+};
+	chosen {
+		bootargs = "root=/dev/vda rootfstype=ext4 rw earlycon console=hvc0";
+	};
+
+};

--- a/hvisor-dev/platform/riscv64/qemu/linker.ld
+++ b/hvisor-dev/platform/riscv64/qemu/linker.ld
@@ -1,0 +1,50 @@
+ENTRY(arch_entry)
+BASE_ADDRESS = 0x80200000;
+
+
+SECTIONS
+{
+    . = BASE_ADDRESS;
+    skernel = .;
+
+    stext = .;
+    .text : {
+        *(.text.entry)
+        *(.text .text.*)
+    }
+
+    . = ALIGN(4K);
+    etext = .;
+    srodata = .;
+    .rodata : {
+        *(.rodata .rodata.*)
+        *(.srodata .srodata.*)
+    }
+
+    . = ALIGN(4K);
+    erodata = .;
+    sdata = .;
+    .data : {
+        *(.data .data.*)
+        *(.sdata .sdata.*)
+    }
+
+    . = ALIGN(4K);
+    edata = .;
+    .bss : {
+        *(.bss.stack)
+        sbss = .;
+        *(.bss .bss.*)
+        *(.sbss .sbss.*)
+    }
+
+    . = ALIGN(4K);
+    ebss = .;
+    ekernel = .;
+
+    /DISCARD/ : {
+        *(.eh_frame)
+    }
+    . = ALIGN(4K);
+	__core_end = .;
+}

--- a/hvisor-dev/platform/riscv64/qemu/platform.mk
+++ b/hvisor-dev/platform/riscv64/qemu/platform.mk
@@ -1,0 +1,55 @@
+include $(DEV_DIR)/platform/common.mk
+
+
+QEMU := qemu-system-riscv64
+
+FSIMG1 := $(IMG_DIR)/rootfs1.ext4
+FSIMG2 := $(IMG_DIR)/rootfs-busybox.qcow2
+
+# HVISOR ENTRY
+HVISOR_ENTRY_PA := 0x80200000
+zone0_kernel := $(IMG_DIR)/Image
+zone0_dtb    := $(PLAT_DIR)/dts/zone0.dtb
+
+QEMU_ARGS := -machine virt
+QEMU_ARGS += -bios default
+QEMU_ARGS += -cpu rv64
+QEMU_ARGS += -smp 4
+QEMU_ARGS += -m 2G
+QEMU_ARGS += -nographic
+
+QEMU_ARGS += -kernel $(hvisor_bin)
+QEMU_ARGS += -device loader,file="$(zone0_kernel)",addr=0x90000000,force-raw=on
+QEMU_ARGS += -device loader,file="$(zone0_dtb)",addr=0x8f000000,force-raw=on
+# QEMU_ARGS += -device loader,file="$(zone1_kernel)",addr=0x84000000,force-raw=on
+# QEMU_ARGS += -device loader,file="$(zone1_dtb)",addr=0x83000000,force-raw=on
+
+QEMU_ARGS += -drive if=none,file=$(FSIMG1),id=X10008000,format=raw
+QEMU_ARGS += -device virtio-blk-device,drive=X10008000,bus=virtio-mmio-bus.7
+QEMU_ARGS += -device virtio-serial-device,bus=virtio-mmio-bus.6 -chardev pty,id=X10007000 -device virtconsole,chardev=X10007000 -S
+QEMU_ARGS += -drive if=none,file=$(FSIMG2),id=X10006000,format=qcow2
+QEMU_ARGS += -device virtio-blk-device,drive=X10006000,bus=virtio-mmio-bus.5
+# -------------------------------------------------------------------
+
+# QEMU_ARGS := -machine virt
+# QEMU_ARGS += -nographic 
+# QEMU_ARGS += -cpu rv64 
+# QEMU_ARGS += -m 3G 
+# QEMU_ARGS += -smp 4 
+# QEMU_ARGS += -bios default
+# # QEMU_ARGS +=-bios $(BOOTLOADER)
+# QEMU_ARGS += -kernel tenants/Image-62
+# QEMU_ARGS += -drive file=imgs/rootfs-busybox.qcow2,format=qcow2,id=hd0 
+# #QEMU_ARGS +=-drive file=../guests/rootfs-buildroot.qcow2,format=qcow2,id=hd0 
+# QEMU_ARGS += -device virtio-blk-device,drive=hd0 
+# QEMU_ARGS += -append "root=/dev/vda rw console=ttyS0"
+
+# #QEMU_ARGS +=		 -device loader,file=$(KERNEL_BIN),addr=$(KERNEL_ENTRY_PA) 
+# #QEMU_ARGS +=		 -device loader,file=../guests/os_ch5_802.bin,addr=0x80400000 			 
+# #QEMU_ARGS +=		 -device virtio-serial-port -chardev pty,id=serial3 -device virtconsole,chardev=serial3
+# QEMU_ARGS +=		 -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3
+
+$(hvisor_bin): elf
+	$(OBJCOPY) $(hvisor_elf) --strip-all -O binary $@
+
+images: dtb


### PR DESCRIPTION
add riscv64 support for branch hvisor-dev, demo is below
```shell
make run ARCH=riscv64
```
then, you can get: 
![1cdb6b86-235c-4cbe-8ab4-56f1be5b2cf0](https://github.com/user-attachments/assets/ef14ddcd-8902-4129-9485-639f36a6f447)
