### PR TITLE
aarch64: fix root linux not booting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ PORT ?= 2333
 MODE ?= debug
 OBJCOPY ?= rust-objcopy --binary-architecture=$(ARCH)
 KDIR ?= ../../linux
-FEATURES ?= platform_zcu102,gicv2
-BOARD ?= zcu102
+FEATURES ?= platform_qemu,gicv3
+BOARD ?= qemu
 
 ifeq ($(ARCH),aarch64)
     RUSTC_TARGET := aarch64-unknown-none

--- a/scripts/qemu-aarch64.mk
+++ b/scripts/qemu-aarch64.mk
@@ -26,7 +26,7 @@ QEMU_ARGS += -global arm-smmuv3.stage=2
 
 QEMU_ARGS += -cpu cortex-a53
 QEMU_ARGS += -smp 4
-QEMU_ARGS += -m 2G
+QEMU_ARGS += -m 3G
 QEMU_ARGS += -nographic
 QEMU_ARGS += -bios $(UBOOT)
 

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -28,7 +28,6 @@ numeric_enum! {
         HvZoneStart = 2,
         HvZoneShutdown = 3,
         HvZoneList = 4,
-        #[cfg(target_arch = "loongarch64")]
         HvClearInjectIrq = 20,
         HvIvcInfo = 5,
     }


### PR DESCRIPTION
## AARCH64
fix: set aarch64 makefile QEMU memory size to 3G to cover `linux1.dts`'s memory region, this will fix the problem of root linux not booting

## LOONGARCH64
fix: remove loongarch cfg control in hypercall enum to avoid compile error