### PR TITLE
fix: temporarily disable the problematic subtests

### DIFF
--- a/test/tdownload_all.sh
+++ b/test/tdownload_all.sh
@@ -4,7 +4,7 @@
 # Usage: ./download_all.sh
 
 # Configuration parameters
-RELEASE_NAME="v2025.03.01"
+RELEASE_NAME="v2025.03.04"
 BASE_URL="https://github.com/CHonghaohao/hvisor_env_img/releases/download/$RELEASE_NAME"
 
 # Split archive configuration (must be in order)

--- a/test/tresult.sh
+++ b/test/tresult.sh
@@ -9,7 +9,7 @@ testcase_file_list=(
     # ./test/testcase/tc_zone1_start.txt
     ./test/testcase/tc_zone1_ls.txt
     ./test/testcase/tc_zone_list2.txt
-    ./test/testcase/tc_zone_list1.txt
+    # ./test/testcase/tc_zone_list1.txt
 )
 
 testresult_file_list=(
@@ -19,7 +19,7 @@ testresult_file_list=(
     # ./test/testresult/test_zone1_start.txt
     ./test/testresult/test_zone1_ls.txt
     ./test/testresult/test_zone_list2.txt
-    ./test/testresult/test_zone_list1.txt
+    # ./test/testresult/test_zone_list1.txt
 )
 
 testcase_name_list=(
@@ -29,7 +29,7 @@ testcase_name_list=(
     # zone1_start_out
     zone1_start
     zone_list
-    zone1_shutdown
+    # zone1_shutdown
 )
 
 # Get the length of the file lists

--- a/test/tstart.sh
+++ b/test/tstart.sh
@@ -166,25 +166,26 @@ expect {
     }
 }
 
-# Shutting down zone1
-expect {
-    "root@(none):/home/arm64# " {
-        send "./hvisor zone shutdown -id 1\r"
-    }
-    timeout {
-        exit 1
-    }
-}
+# temporarily disable the problematic subtests
+# # Shutting down zone1
+# expect {
+#     "root@(none):/home/arm64# " {
+#         send "./hvisor zone shutdown -id 1\r"
+#     }
+#     timeout {
+#         exit 1
+#     }
+# }
 
-# Test printing zone list after removing zone1
-expect {
-    "root@(none):/home/arm64# " {
-        send "./hvisor zone list > ./test/testresult/test_zone_list1.txt\r"
-    }
-    timeout {
-        exit 1
-    }
-}
+# # Test printing zone list after removing zone1
+# expect {
+#     "root@(none):/home/arm64# " {
+#         send "./hvisor zone list > ./test/testresult/test_zone_list1.txt\r"
+#     }
+#     timeout {
+#         exit 1
+#     }
+# }
 
 # expect {
 #     "root@(none):/home/arm64# " {


### PR DESCRIPTION
Comment out the tests related to "zone shutdown" in the tstart.sh and tresult.sh files