### PR TITLE
[Fix] fix qemu-aarch64 config & dts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,9 @@
 /test-img
 /hvisor.S
 /hvisor-elf.txt
-/images/aarch64/virtdisk/*
-/images/aarch64/kernel/*
-/images/aarch64/devicetree/*.dtb
-/images/riscv64/virtdisk/*
-/images/riscv64/kernel/*
-/images/riscv64/devicetree/*.dtb
+/images/*
+/platform/*/*/image/kernel/*
+/platform/*/*/image/virtdisk/*
 /tools/hvisor
 /tmp
 *.mod.[co]

--- a/platform/aarch64/qemu-gicv2/cargo/config.template.toml
+++ b/platform/aarch64/qemu-gicv2/cargo/config.template.toml
@@ -2,6 +2,6 @@
 runner = "platform/__ARCH__/__BOARD__/test/runner.sh"
 rustflags = [
     "-Clink-arg=-Tplatform/__ARCH__/__BOARD__/linker.ld",
-    "-Ctarget-feature=+a53,+v8a,+strict-align,-neon,-fp-armv8",
+    "-Ctarget-feature=+a72,+v8a,+strict-align,-neon,-fp-armv8",
     "-Cforce-frame-pointers=yes",
 ]

--- a/platform/aarch64/qemu-gicv2/image/dts/zone0.dts
+++ b/platform/aarch64/qemu-gicv2/image/dts/zone0.dts
@@ -15,7 +15,7 @@
 			phandle = <0x8010>;
 			reg = <0x00>;
 			enable-method = "psci";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a72";
 			device_type = "cpu";
 		};
 
@@ -23,7 +23,7 @@
 			phandle = <0x800f>;
 			reg = <0x01>;
 			enable-method = "psci";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a72";
 			device_type = "cpu";
 		};
 	};

--- a/platform/aarch64/qemu-gicv3/cargo/config.template.toml
+++ b/platform/aarch64/qemu-gicv3/cargo/config.template.toml
@@ -2,6 +2,6 @@
 runner = "platform/__ARCH__/__BOARD__/test/runner.sh"
 rustflags = [
     "-Clink-arg=-Tplatform/__ARCH__/__BOARD__/linker.ld",
-    "-Ctarget-feature=+a53,+v8a,+strict-align,-neon,-fp-armv8",
+    "-Ctarget-feature=+a72,+v8a,+strict-align,-neon,-fp-armv8",
     "-Cforce-frame-pointers=yes",
 ]

--- a/platform/aarch64/qemu-gicv3/configs/zone1-linux.json
+++ b/platform/aarch64/qemu-gicv3/configs/zone1-linux.json
@@ -26,9 +26,12 @@
     "dtb_load_paddr":   "0x50000000",
     "entry_point":      "0x50400000",
     "arch_config": {
+        "gic_version": "v3",
         "gicd_base": "0x8000000",
         "gicd_size": "0x10000",
         "gicr_base": "0x80a0000",
-        "gicr_size": "0xf60000"
+        "gicr_size": "0xf60000",
+        "gits_base": "0x8080000",
+        "gits_size": "0x20000"
     }
 }

--- a/platform/aarch64/qemu-gicv3/configs/zone1-ruxos.json
+++ b/platform/aarch64/qemu-gicv3/configs/zone1-ruxos.json
@@ -25,9 +25,12 @@
     "dtb_load_paddr":   "0x50000000",
     "entry_point":      "0x40080000",
     "arch_config": {
+        "gic_version": "v3",
         "gicd_base": "0x8000000",
         "gicd_size": "0x10000",
         "gicr_base": "0x80a0000",
-        "gicr_size": "0xf60000"
+        "gicr_size": "0xf60000",
+        "gits_base": "0x8080000",
+        "gits_size": "0x20000"
     }
 }

--- a/platform/aarch64/qemu-gicv3/image/dts/zone1-linux.dts
+++ b/platform/aarch64/qemu-gicv3/image/dts/zone1-linux.dts
@@ -14,14 +14,14 @@
 		cpu@2 {
 			reg = <0x02>;
 			enable-method = "psci";
-			compatible = "arm,cortex-a57";
+			compatible = "arm,cortex-a72";
 			device_type = "cpu";
 		};
 
 		cpu@3 {
 			reg = <0x03>;
 			enable-method = "psci";
-			compatible = "arm,cortex-a57";
+			compatible = "arm,cortex-a72";
 			device_type = "cpu";
 		};
 

--- a/platform/aarch64/qemu-gicv3/image/dts/zone1-ruxos.dts
+++ b/platform/aarch64/qemu-gicv3/image/dts/zone1-ruxos.dts
@@ -22,7 +22,7 @@
 
 		cpu@2 {
 			device_type = "cpu";
-			compatible = "arm,cortex-a53";
+			compatible = "arm,cortex-a72";
 			reg = <0x02>;
 			clock-latency = <0xee6c>;
 			next-level-cache = <0x02>;
@@ -41,7 +41,7 @@
 	};
 
 	pmu {
-		compatible = "arm,cortex-a53-pmu";
+		compatible = "arm,cortex-a72-pmu";
 		interrupts = <0x01 0x07 0x04>;
 		interrupt-parent = <0x01>;
 		interrupt-affinity = <0x03 0x04>;

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -212,7 +212,14 @@ impl<'a> HyperCall<'a> {
             );
         }
         if config_size != core::mem::size_of::<HvZoneConfig>() as _ {
-            return hv_result_err!(EINVAL, "Invalid config!");
+            return hv_result_err!(
+                EINVAL,
+                format!(
+                    "hv_zone_start: config size should be {} bytes, but got {}",
+                    core::mem::size_of::<HvZoneConfig>(),
+                    config_size
+                )
+            );
         }
         let zone = zone_create(config)?;
         let boot_cpu = zone.read().cpu_set.first_cpu().unwrap();


### PR DESCRIPTION
1. Switch CPU to Cortex-A72 in platform and dts files.
2. Add gic fields in qemu-gicv3 configs.
3. Improve config_size error message in hypercall/mod.rs.

