### PR TITLE
feat: Enable dynamic CPU detection for ARM platforms via device tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,8 +98,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type-rs"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6419a5c75e40011b9fe0174db3fe24006ab122fbe1b7e9cc5974b338a755c76"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fdt"
 version = "0.1.5"
+
+[[package]]
+name = "fdt-rs"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581d3afdd654deb68c19fcbe4bc411910cc64067d4a13d8637bda7722cb9c2ea"
+dependencies = [
+ "endian-type-rs",
+ "fallible-iterator",
+ "memoffset",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "static_assertions",
+ "unsafe_unwrap",
+]
 
 [[package]]
 name = "hvisor"
@@ -113,6 +141,7 @@ dependencies = [
  "cfg-if",
  "cortex-a",
  "fdt",
+ "fdt-rs",
  "lazy_static",
  "log",
  "loongArch64",
@@ -172,6 +201,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "numeric-enum-macro"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "psci"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +261,15 @@ name = "qemu-exit"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -343,10 +419,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tock-registers"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe_unwrap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1230ec65f13e0f9b28d789da20d2d419511893ea9dac2c1f4ef67b8b14e5da80"
 
 [[package]]
 name = "volatile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ qemu-exit = "3.0.2"
 cortex-a = "8.1.1"
 cfg-if = "1.0"
 
+[dependencies.fdt-rs]
+version = "0.4.5"
+default-features = false
+
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "9.4.0"
 psci = { version = "0.1.0", default-features = false, features = ["smc"]}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,18 +16,20 @@ pub const INVALID_ADDRESS: usize = usize::MAX;
 #[cfg(target_arch = "loongarch64")]
 pub const MAX_CPU_NUM: usize = 4;
 #[cfg(target_arch = "aarch64")]
-pub const MAX_CPU_NUM: usize = 4;
+pub const MAX_CPU_NUM: usize = 32;
 #[cfg(target_arch = "riscv64")]
 pub const MAX_CPU_NUM: usize = 4;
 
 pub const MAX_ZONE_NUM: usize = 3;
+
+pub static mut NCPU: usize = MAX_CPU_NUM;
 
 pub fn core_end() -> VirtAddr {
     __core_end as _
 }
 
 pub fn mem_pool_start() -> VirtAddr {
-    core_end() + MAX_CPU_NUM * PER_CPU_SIZE
+    core_end() + unsafe {NCPU} * PER_CPU_SIZE
 }
 
 pub fn hv_end() -> VirtAddr {

--- a/src/device/irqchip/gicv2/gic.rs
+++ b/src/device/irqchip/gicv2/gic.rs
@@ -7,6 +7,7 @@ use crate::device::irqchip::gicv2::gich::{
 };
 use crate::event::check_events;
 use crate::hypercall::SGI_IPI_ID;
+use crate::consts;
 /// This file defines and implements the functional functions of physical gicv2.
 /// author: ForeverYolo
 /// reference:
@@ -15,7 +16,7 @@ use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use spin::{Mutex, Once};
 
-pub const MAX_CPU_NUM: usize = 8;
+pub const MAX_CPU_NUM: usize = consts::MAX_CPU_NUM;
 pub const MAINTENACE_INTERRUPT: u64 = 25;
 
 pub fn gicv2_handle_irq() {

--- a/src/device/irqchip/gicv2/mod.rs
+++ b/src/device/irqchip/gicv2/mod.rs
@@ -1,4 +1,5 @@
 use crate::device::irqchip::gicv2::gic::MAX_CPU_NUM;
+use crate::consts;
 /// The outer layer is defined using gicv2.
 /// author: ForeverYolo
 /// reference:
@@ -54,7 +55,7 @@ pub fn primary_init_early() {
     info!("GicCpuInterface = {:#x?}", GICV2.gicc_base);
     info!("GicHypervisorInterface = {:#x?}", GICV2.gich_base);
     info!("GicVCpuInterface = {:#x?}", GICV2.gicv_base);
-    gic::PENDING_VIRQS.call_once(|| gic::PendingIrqs::new(MAX_CPU_NUM));
+    gic::PENDING_VIRQS.call_once(|| gic::PendingIrqs::new(unsafe {consts::NCPU}));
 }
 
 pub fn percpu_init() {

--- a/src/device/irqchip/gicv3/gicr.rs
+++ b/src/device/irqchip/gicv3/gicr.rs
@@ -11,6 +11,7 @@ use spin::{mutex::Mutex, Once};
 
 use crate::{
     arch::cpu::this_cpu_id,
+    consts,
     consts::{MAX_CPU_NUM, MAX_ZONE_NUM, PAGE_SIZE},
     hypercall::SGI_IPI_ID,
     memory::Frame,
@@ -93,7 +94,7 @@ impl LpiPropTable {
         let page_num: usize = ((1 << (id_bits + 1)) - 8192) / PAGE_SIZE;
         let f = Frame::new_contiguous(page_num, 0).unwrap();
         let propreg = f.start_paddr() | 0x78f;
-        for id in 0..MAX_CPU_NUM {
+        for id in 0..unsafe {consts::NCPU} {
             let propbaser = host_gicr_base(id) + GICR_PROPBASER;
             unsafe {
                 ptr::write_volatile(propbaser as *mut u64, propreg as _);

--- a/src/device/irqchip/gicv3/mod.rs
+++ b/src/device/irqchip/gicv3/mod.rs
@@ -97,7 +97,7 @@ use self::gicr::enable_ipi;
 use crate::arch::aarch64::sysreg::{read_sysreg, smc_arg1, write_sysreg};
 use crate::arch::cpu::this_cpu_id;
 use crate::config::root_zone_config;
-use crate::consts::MAX_CPU_NUM;
+use crate::consts;
 
 use crate::event::check_events;
 use crate::hypercall::SGI_IPI_ID;
@@ -407,7 +407,7 @@ pub fn host_gicd_base() -> usize {
 }
 
 pub fn host_gicr_base(id: usize) -> usize {
-    assert!(id < MAX_CPU_NUM);
+    assert!(id < consts::MAX_CPU_NUM);
     GIC.get().unwrap().gicr_base + id * PER_GICR_SIZE
 }
 
@@ -461,7 +461,7 @@ pub fn primary_init_early() {
         gits_init();
     }
 
-    PENDING_VIRQS.call_once(|| PendingIrqs::new(MAX_CPU_NUM));
+    PENDING_VIRQS.call_once(|| PendingIrqs::new(unsafe {consts::NCPU}));
     debug!("gic = {:#x?}", GIC.get().unwrap());
 }
 

--- a/src/device/irqchip/gicv3/vgic.rs
+++ b/src/device/irqchip/gicv3/vgic.rs
@@ -3,7 +3,7 @@ use alloc::sync::Arc;
 use super::{gicd::GICD_LOCK, is_spi};
 use crate::{
     arch::zone::HvArchZoneConfig,
-    consts::MAX_CPU_NUM,
+    consts,
     device::irqchip::gicv3::{
         gicd::*, gicr::*, gits::*, host_gicd_base, host_gicr_base, host_gits_base,
         MAINTENACE_INTERRUPT, PER_GICR_SIZE,
@@ -28,7 +28,7 @@ impl Zone {
         self.mmio_region_register(arch.gicd_base, arch.gicd_size, vgicv3_dist_handler, 0);
         self.mmio_region_register(arch.gits_base, arch.gits_size, vgicv3_its_handler, 0);
 
-        for cpu in 0..MAX_CPU_NUM {
+        for cpu in 0..unsafe {consts::NCPU} {
             let gicr_base = arch.gicr_base + cpu * PER_GICR_SIZE;
             debug!("registering gicr {} at {:#x?}", cpu, gicr_base);
             self.mmio_region_register(gicr_base, PER_GICR_SIZE, vgicv3_redist_handler, cpu);
@@ -138,7 +138,7 @@ pub fn vgicv3_redist_handler(mmio: &mut MMIOAccess, cpu: usize) -> HvResult {
         }
         GICR_TYPER => {
             mmio_perform_access(gicr_base, mmio);
-            if cpu == MAX_CPU_NUM - 1 {
+            if cpu == unsafe {consts::NCPU} - 1 {
                 mmio.value |= GICR_TYPER_LAST;
             }
         }

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -7,6 +7,7 @@ use core::sync::atomic::Ordering;
 use spin::Mutex;
 
 use crate::arch::cpu::this_cpu_id;
+use crate::consts;
 use crate::consts::MAX_CPU_NUM;
 use crate::device::irqchip::inject_irq;
 use crate::event::send_event;
@@ -54,8 +55,8 @@ pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
     // debug!("non root sends req: {:#x?}", hreq);
     let (cfg_flags, cfg_values) = unsafe {
         (
-            core::slice::from_raw_parts(dev.get_cfg_flags(), MAX_CPU_NUM),
-            core::slice::from_raw_parts(dev.get_cfg_values(), MAX_CPU_NUM),
+            core::slice::from_raw_parts(dev.get_cfg_flags(), unsafe {consts::NCPU}),
+            core::slice::from_raw_parts(dev.get_cfg_values(), unsafe {consts::NCPU}),
         )
     };
     let cpu_id = this_cpu_id() as usize;

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 use crate::arch::cpu::this_cpu_id;
 use crate::config::HvZoneConfig;
-use crate::consts::{INVALID_ADDRESS, MAX_CPU_NUM, PAGE_SIZE};
+use crate::consts;
+use crate::consts::{INVALID_ADDRESS, PAGE_SIZE};
 use crate::device::irqchip::inject_irq;
 use crate::device::virtio_trampoline::{MAX_DEVS, MAX_REQ, VIRTIO_BRIDGE, VIRTIO_IRQS};
 use crate::error::HvResult;
@@ -68,7 +69,7 @@ impl<'a> HyperCall<'a> {
                 HyperCallCode::HvZoneList => self.hv_zone_list(&mut *(arg0 as *mut ZoneInfo), arg1),
                 HyperCallCode::HvClearInjectIrq => {
                     use crate::event::IPI_EVENT_CLEAR_INJECT_IRQ;
-                    for i in 1..MAX_CPU_NUM {
+                    for i in 1..unsafe {consts::NCPU} {
                         // if target cpu status is not running, we skip it
                         if !get_cpu_data(i).arch_cpu.power_on {
                             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ mod error;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
+
+extern crate fdt_rs;
+
 #[macro_use]
 mod logging;
 mod arch;
@@ -56,6 +59,7 @@ use crate::arch::mm::setup_parange;
 use crate::consts::MAX_CPU_NUM;
 use arch::{cpu::cpu_start, entry::arch_entry};
 use config::root_zone_config;
+use fdt_rs::{base::DevTree, prelude::FallibleIterator};
 use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use percpu::PerCpu;
 use zone::zone_create;
@@ -93,7 +97,7 @@ fn wait_for_counter(counter: &AtomicU32, max_value: u32) {
     wait_for(|| counter.load(Ordering::Acquire) < max_value)
 }
 
-fn primary_init_early() {
+fn primary_init_early(ncpu: usize) {
     extern "C" {
         fn __core_end();
     }
@@ -112,7 +116,7 @@ fn primary_init_early() {
     );
     memory::frame::init();
     memory::frame::test();
-    event::init(MAX_CPU_NUM);
+    event::init(ncpu);
 
     device::irqchip::primary_init_early();
     // crate::arch::mm::init_hv_page_table().unwrap();
@@ -143,8 +147,8 @@ fn per_cpu_init(cpu: &mut PerCpu) {
     info!("CPU {} hv_pt_install OK.", cpu.id);
 }
 
-fn wakeup_secondary_cpus(this_id: usize, host_dtb: usize) {
-    for cpu_id in 0..MAX_CPU_NUM {
+fn wakeup_secondary_cpus(this_id: usize, host_dtb: usize, ncpu: usize) {
+    for cpu_id in 0..ncpu {
         if cpu_id == this_id {
             continue;
         }
@@ -173,13 +177,49 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
         cpu.id, cpu as *const _, &cpu.arch_cpu as *const _, host_dtb
     );
 
+
+    // Don't you wanna know how many cpu(s) on board? :D
+    let mut ncpu: usize = 0;
+    #[cfg(target_arch = "aarch64")]
+    {
+        let devtree = unsafe {
+            DevTree::from_raw_pointer(host_dtb as *const u8).unwrap()
+        };
+
+        let mut node_iter = devtree.nodes();
+        while let Some(node) = node_iter.next().unwrap() {
+            if node.name().unwrap().starts_with("cpu@") {
+                ncpu += 1;
+            }
+        }
+    }
+
+
+
     if is_primary {
-        wakeup_secondary_cpus(cpu.id, host_dtb);
+        // If we failed to detect, just use default value.
+        if ncpu == 0 {
+            println!("Failed to count cpu(s) from devicetree. Using default value {}.", MAX_CPU_NUM);
+            ncpu = MAX_CPU_NUM;
+        }
+        else if ncpu > MAX_CPU_NUM {
+            println!("{} cpu(s) detected, but using only {}.", ncpu, MAX_CPU_NUM);
+            ncpu = MAX_CPU_NUM;
+        }
+
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            println!("Using {} cpu(s) on this system.", ncpu);
+        }
+        
+        unsafe {consts::NCPU = ncpu;}
+        wakeup_secondary_cpus(cpu.id, host_dtb, ncpu);
     }
 
     ENTERED_CPUS.fetch_add(1, Ordering::SeqCst);
-    wait_for(|| PerCpu::entered_cpus() < MAX_CPU_NUM as _);
-    assert_eq!(PerCpu::entered_cpus(), MAX_CPU_NUM as _);
+    wait_for(|| PerCpu::entered_cpus() < ncpu as _);
+    assert_eq!(PerCpu::entered_cpus(), ncpu as _);
 
     println!(
         "{} CPU {} has entered.",
@@ -188,10 +228,10 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
     );
 
     #[cfg(target_arch = "aarch64")]
-    setup_parange();
+    setup_parange(ncpu);
 
     if is_primary {
-        primary_init_early(); // create root zone here
+        primary_init_early(ncpu); // create root zone here
     } else {
         wait_for_counter(&INIT_EARLY_OK, 1);
     }
@@ -201,7 +241,7 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
 
     INITED_CPUS.fetch_add(1, Ordering::SeqCst);
 
-    wait_for_counter(&INITED_CPUS, MAX_CPU_NUM as _);
+    wait_for_counter(&INITED_CPUS, ncpu as _);
 
     if is_primary {
         primary_init_late();

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -8,7 +8,7 @@ use spin::RwLock;
 use crate::arch::mm::new_s2_memory_set;
 use crate::arch::s2pt::Stage2PageTable;
 use crate::config::{HvZoneConfig, CONFIG_NAME_MAXLEN};
-use crate::consts::MAX_CPU_NUM;
+use crate::consts;
 
 use crate::error::HvResult;
 use crate::memory::addr::GuestPhysAddr;
@@ -32,7 +32,7 @@ impl Zone {
             name: name.try_into().unwrap(),
             id: zoneid,
             gpm: new_s2_memory_set(),
-            cpu_set: CpuSet::new(MAX_CPU_NUM as usize, 0),
+            cpu_set: CpuSet::new(unsafe {consts::NCPU} as usize, 0),
             mmio: Vec::new(),
             irq_bitmap: [0; 1024 / 32],
             pciroot: PciRoot::new(),


### PR DESCRIPTION
Previously, the system was limited to a maximum of 4 CPUs. This change allows the system to dynamically detect the number of available CPUs on ARM platforms by reading the device tree and utilize them fully (up to 32 cores).