### PR TITLE
riscv64: add virtio support

### DIFF
--- a/platform/riscv64/qemu-plic/board.rs
+++ b/platform/riscv64/qemu-plic/board.rs
@@ -26,7 +26,7 @@ pub const BOARD_PLIC_INTERRUPTS_NUM: usize = 1023;  // except irq 0
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;
 pub const ROOT_ZONE_ENTRY: u64 = 0x90000000;
-pub const ROOT_ZONE_CPUS: u64 = (1 << 0) | (1 << 1) | (1 << 2);
+pub const ROOT_ZONE_CPUS: u64 = (1 << 0) | (1 << 1);
 
 pub const ROOT_ZONE_NAME: &str = "root-linux";
 
@@ -87,7 +87,12 @@ pub const ROOT_ZONE_MEMORY_REGIONS: [HvConfigMemoryRegion; 9] = [
     }, // virtio
 ];
 
-pub const ROOT_ZONE_IRQS: [u32; 11] = [1, 2, 3, 4, 5, 8, 10, 33, 34, 35, 36]; // ARCH= riscv .It doesn't matter temporarily.
+// Note: all here's irqs are hardware irqs,
+//  only these irq can be transferred to the physical PLIC.
+pub const HW_IRQS: [u32; 11] = [1, 2, 3, 4, 5, 8, 10, 33, 34, 35, 36];
+
+// irqs belong to the root zone.
+pub const ROOT_ZONE_IRQS: [u32; 11] = [1, 2, 3, 4, 5, 8, 10, 33, 34, 35, 36];
 
 pub const ROOT_ARCH_ZONE_CONFIG: HvArchZoneConfig = HvArchZoneConfig {
     plic_base: 0xc000000,

--- a/platform/riscv64/qemu-plic/configs/virtio_cfg.json
+++ b/platform/riscv64/qemu-plic/configs/virtio_cfg.json
@@ -1,0 +1,31 @@
+{
+    "zones": [
+        {
+            "id": 1,
+            "memory_region": [
+                {
+                    "zone0_ipa": "0x83000000",
+                    "zonex_ipa": "0x83000000",
+                    "size": "0x0C000000"
+                }
+            ],
+            "devices": [
+                    {
+                        "type": "blk",
+                        "addr": "0x10006000",
+                        "len": "0x1000",
+                        "irq": 6,
+                        "img": "rootfs2.ext4",
+                        "status": "enable"
+                    },
+                    {
+                        "type": "console",
+                        "addr": "0x10007000",
+                        "len": "0x1000",
+                        "irq": 7,
+                        "status": "enable"
+                    }
+                ]
+        }
+    ]
+}

--- a/platform/riscv64/qemu-plic/configs/zone1-linux-virtio.json
+++ b/platform/riscv64/qemu-plic/configs/zone1-linux-virtio.json
@@ -2,7 +2,7 @@
     "arch": "riscv",
     "name": "linux2",
     "zone_id": 1,
-    "cpus": [3],
+    "cpus": [2, 3],
     "memory_regions": [
         {
             "type": "ram",
@@ -11,13 +11,13 @@
             "size": "0x0C000000"
         },
         {
-            "type": "io",
+            "type": "virtio",
             "physical_start": "0x10007000",
             "virtual_start": "0x10007000",
             "size": "0x1000"
         },
         {
-            "type": "io",
+            "type": "virtio",
             "physical_start": "0x10006000",
             "virtual_start": "0x10006000",
             "size": "0x1000"

--- a/platform/riscv64/qemu-plic/image/dts/zone0.dts
+++ b/platform/riscv64/qemu-plic/image/dts/zone0.dts
@@ -38,21 +38,6 @@
 				compatible = "riscv,cpu-intc";
 			};
 		};
-		cpu@2 {
-			device_type = "cpu";
-			reg = <0x2>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdcsu_sstc";
-			mmu-type = "riscv,sv39";
-
-			cpu2_intc: interrupt-controller {
-				#interrupt-cells = <0x1>;
-				interrupt-controller;
-				compatible = "riscv,cpu-intc";
-			};
-		};
-
 	};
 
 	memory@80000000 {
@@ -99,7 +84,6 @@
 			interrupts-extended = <
 				&cpu0_intc 11 &cpu0_intc 9 
 				&cpu1_intc 11 &cpu1_intc 9 
-				&cpu2_intc 11 &cpu2_intc 9
 			>;
 			interrupt-controller;
 			compatible = "riscv,plic0";
@@ -156,6 +140,13 @@
 			compatible = "virtio,mmio";
 		};
 	};
+
+	hvisor_virtio_device {
+		compatible = "hvisor";
+    	interrupt-parent = <&plic>;
+    	interrupts = <0x20>;
+	};
+
 	chosen {
 		bootargs = "root=/dev/vda rw earlycon console=ttyS0";
 	};

--- a/platform/riscv64/qemu-plic/image/dts/zone1-linux.dts
+++ b/platform/riscv64/qemu-plic/image/dts/zone1-linux.dts
@@ -1,107 +1,84 @@
 /dts-v1/;
 
 / {
-	#address-cells = <0x2>;
-	#size-cells = <0x2>;
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
 
 	cpus {
-		#address-cells = <0x1>;
-		#size-cells = <0x0>;
-		timebase-frequency = <10000000>;
-		cpu@3 {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x989680>;
+
+		cpu@2 {
 			device_type = "cpu";
-			reg = <0x3>;
+			reg = <0x02>;
 			status = "okay";
 			compatible = "riscv";
 			riscv,isa = "rv64imafdcsu_sstc";
 			mmu-type = "riscv,sv39";
 
-			cpu3_intc: interrupt-controller {
-				#interrupt-cells = <0x1>;
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
 				interrupt-controller;
 				compatible = "riscv,cpu-intc";
+				phandle = <0x01>;
 			};
 		};
 
+		cpu@3 {
+			device_type = "cpu";
+			reg = <0x03>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa = "rv64imafdcsu_sstc";
+			mmu-type = "riscv,sv39";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x03>;
+			};
+		};
 	};
 
-	memory@84000000 {
+	memory@83000000 {
 		device_type = "memory";
-		reg = <0x0 0x84000000 0x0 0x08000000>;
+		reg = <0x00 0x83000000 0x00 0x0C000000>;
 	};
-soc{
-			#address-cells = <0x02>;
+
+	soc {
+		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		compatible = "simple-bus";
 		ranges;
-	plic: interrupt-controller@c000000 {
-		riscv,ndev = <60>;
-		reg = <0x0 0xc000000 0x0 0x4000000>;
-		interrupts-extended = <
-			&cpu3_intc 11 &cpu3_intc 9
-		>;
-		interrupt-controller;
-		compatible = "riscv,plic0";
-		#interrupt-cells = <0x1>;
+
+		interrupt-controller@c000000 {
+			riscv,ndev = <0x3c>;
+			reg = <0x00 0xc000000 0x00 0x4000000>;
+			interrupts-extended = <0x01 0x0b 0x01 0x09 0x03 0x0b 0x03 0x09>;
+			interrupt-controller;
+			compatible = "riscv,plic0";
+			#interrupt-cells = <0x01>;
+			phandle = <0x02>;
+		};
+
+		virtio_mmio@10007000 {
+			interrupts = <0x07>;
+			interrupt-parent = <0x02>;
+			reg = <0x00 0x10007000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10006000 {
+			interrupts = <0x06>;
+			interrupt-parent = <0x02>;
+			reg = <0x00 0x10006000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
 	};
 
-//		virtio_mmio@10008000 {
-//		interrupts = <0x8>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10008000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-	virtio_mmio@10007000 {
-		interrupts = <0x7>;
-		interrupt-parent = <&plic>;
-		reg = <0x0 0x10007000 0x0 0x1000>;
-		compatible = "virtio,mmio";
-	};
-	virtio_mmio@10006000 {
-		interrupts = <0x6>;
-		interrupt-parent = <&plic>;
-		reg = <0x0 0x10006000 0x0 0x1000>;
-		compatible = "virtio,mmio";
-	};
-//
-//	virtio_mmio@10005000 {
-//		interrupts = <0x5>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10005000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-//
-//	virtio_mmio@10004000 {
-//		interrupts = <0x4>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10004000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-//
-//	virtio_mmio@10003000 {
-//		interrupts = <0x3>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10003000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-//
-//	virtio_mmio@10002000 {
-//		interrupts = <0x2>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10002000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-//
-//	virtio_mmio@10001000 {
-//		interrupts = <0x1>;
-//		interrupt-parent = <&plic>;
-//		reg = <0x0 0x10001000 0x0 0x1000>;
-//		compatible = "virtio,mmio";
-//	};
-
-};
 	chosen {
-		bootargs = "root=/dev/vda rootfstype=ext4 rw earlycon console=hvc0";
+		bootargs = "root=/dev/vda rw earlycon console=hvc0";
 	};
-
 };

--- a/src/arch/riscv64/ipi.rs
+++ b/src/arch/riscv64/ipi.rs
@@ -17,7 +17,7 @@ use sbi_rt::HartMask;
 
 // arch_send_event
 pub fn arch_send_event(cpu_id: u64, _sgi_num: u64) {
-    info!("arch_send_event: cpu_id: {}", cpu_id);
+    debug!("arch_send_event: cpu_id: {}", cpu_id);
     #[cfg(feature = "aclint")]
     crate::device::irqchip::aclint::aclint_send_ipi(cpu_id as usize);
     #[cfg(not(feature = "aclint"))]

--- a/src/arch/riscv64/sbi.rs
+++ b/src/arch/riscv64/sbi.rs
@@ -264,7 +264,7 @@ pub fn sbi_hvisor_handler(current_cpu: &mut ArchCpu) -> SbiRet {
     let (code, arg0, arg1) = (current_cpu.x[10], current_cpu.x[11], current_cpu.x[12]);
 
     let cpu_data = this_cpu_data();
-    info!(
+    debug!(
         "HVC from CPU{},code:{:#x?},arg0:{:#x?},arg1:{:#x?}",
         cpu_data.id, code, arg0, arg1
     );

--- a/src/device/irqchip/aclint/mod.rs
+++ b/src/device/irqchip/aclint/mod.rs
@@ -62,7 +62,7 @@ pub fn aclint_init(base_addr: usize) {
 pub fn aclint_send_ipi(hart_id: usize) {
     assert!(hart_id < MAX_CPU_NUM, "hart_id is out of range");
 
-    info!("ACLINT: addr {:#x}", *ACLINT_BASE.get().unwrap());
+    debug!("ACLINT: addr {:#x}", *ACLINT_BASE.get().unwrap());
 
     let sswi = unsafe { SSWI::new(*ACLINT_BASE.get().unwrap() as usize) };
     let setssip = sswi.setssip(HartId::from_number(hart_id).unwrap());

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -48,7 +48,6 @@ pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;
 #[cfg(target_arch = "riscv64")]
 pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 0x20;
 
-
 /// non root zone's virtio request handler
 pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
     // debug!("mmio virtio handler");

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -42,7 +42,12 @@ const QUEUE_NOTIFY: usize = 0x50;
 pub const MAX_REQ: u32 = 32;
 pub const MAX_DEVS: usize = 4; // Attention: The max virtio-dev number for vm is 4.
 pub const MAX_CPUS: usize = 4;
+
+#[cfg(not(target_arch = "riscv64"))]
 pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;
+#[cfg(target_arch = "riscv64")]
+pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 0x20;
+
 
 /// non root zone's virtio request handler
 pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {


### PR DESCRIPTION
- modify zone0's cpu num to 2
- add HW_IRQS in board.rs (only these irqs will be operated in related physical PLIC)
- virtio irq is 0x20 (different from arm's 0x20+32)
- add related json files in platform dir ( can easily repeat )

Below is the output of zone1 with virtio console:
![image](https://github.com/user-attachments/assets/0a311683-8387-465b-9422-ad4a143104bc)
