### PR TITLE
riscv64: move sstc to features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ pt_layout_qemu = []
 plic = []
 aia = []
 aclint = []
+# extensions
+sstc = []
 ########### loongarch64 ############
 # irqchip driver
 loongson_7a2000 = []

--- a/platform/riscv64/qemu-plic/cargo/features
+++ b/platform/riscv64/qemu-plic/cargo/features
@@ -1,2 +1,3 @@
-plic
 aclint
+plic
+sstc

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -1,12 +1,12 @@
 QEMU := qemu-system-riscv64
 
 
-FSIMG1 := /home/jingyu/workspace/autobuild/ubuntu-rootfs.ext4
-FSIMG2 := /home/jingyu/workspace/pr/hvisor/platform/riscv64/qemu-plic/image/virtdisk/rootfs-busybox.qcow2
+FSIMG1 := $(image_dir)/virtdisk/rootfs1.ext4
+FSIMG2 := $(image_dir)/virtdisk/rootfs-busybox.qcow2
 # HVISOR ENTRY
 HVISOR_ENTRY_PA := 0x80200000
-zone0_kernel := /home/jingyu/riscv-linux-devel/arch/riscv/boot/Image
-zone0_dtb    := /home/jingyu/workspace/pr/hvisor-dev/platform/riscv64/qemu-plic/image/dts/zone0.dtb
+zone0_kernel := $(image_dir)/kernel/Image
+zone0_dtb    := $(image_dir)/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -1,12 +1,12 @@
 QEMU := qemu-system-riscv64
 
 
-FSIMG1 := $(image_dir)/virtdisk/rootfs1.ext4
-FSIMG2 := $(image_dir)/virtdisk/rootfs-busybox.qcow2
+FSIMG1 := /home/jingyu/workspace/autobuild/ubuntu-rootfs.ext4
+FSIMG2 := /home/jingyu/workspace/pr/hvisor/platform/riscv64/qemu-plic/image/virtdisk/rootfs-busybox.qcow2
 # HVISOR ENTRY
 HVISOR_ENTRY_PA := 0x80200000
-zone0_kernel := $(image_dir)/kernel/Image
-zone0_dtb    := $(image_dir)/dts/zone0.dtb
+zone0_kernel := /home/jingyu/riscv-linux-devel/arch/riscv/boot/Image
+zone0_dtb    := /home/jingyu/workspace/pr/hvisor-dev/platform/riscv64/qemu-plic/image/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 

--- a/src/arch/riscv64/cpu.rs
+++ b/src/arch/riscv64/cpu.rs
@@ -53,7 +53,7 @@ impl ArchCpu {
             // first_cpu: 0,
             power_on: false,
             init: false,
-            sstc: false,
+            sstc: cfg!(feature = "sstc"),
         };
         ret
     }


### PR DESCRIPTION
Move sstc extension to features.
Then configure feature to enable or disable sstc extension.
When use sstc, VS can use timcmp register (vstimecmp).