### PR TITLE
riscv64: improve sbi and ipi code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "psci",
  "qemu-exit",
  "raw-cpuid",
+ "riscv 0.13.0",
  "riscv 0.6.0",
  "riscv-decode",
  "riscv-pac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ psci = { version = "0.1.0", default-features = false, features = ["smc"]}
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 sbi-rt = { version = "0.0.3", features = ["legacy"] }
 sbi-spec = "0.0.8"
-riscv = { git = "https://github.com/rcore-os/riscv", features = ["inline-asm"] }
+riscv = "0.13.0"
+riscv_h = { package = "riscv", git = "https://github.com/rcore-os/riscv", features = ["inline-asm"] }
 riscv-decode = "0.2.1"
 riscv-peripheral = "0.2.1"
 riscv-pac = "0.2.0"

--- a/src/arch/riscv64/csr.rs
+++ b/src/arch/riscv64/csr.rs
@@ -57,6 +57,8 @@ pub const CSR_HENVCFGH: u64 = 0x61A;
 pub const CSR_STIMECMP: u64 = 0x14D;
 pub const CSR_STIMECMPH: u64 = 0x15D;
 
+pub const HSTATUS_SPV: u64 = 1 << 7;
+
 macro_rules! read_csr {
     ($csr_number:expr) => {
         {
@@ -73,6 +75,7 @@ macro_rules! read_csr {
     }
 }
 pub(crate) use read_csr;
+
 macro_rules! write_csr {
     ($csr_number:expr, $value: expr) => {
         unsafe{

--- a/src/arch/riscv64/ipi.rs
+++ b/src/arch/riscv64/ipi.rs
@@ -23,3 +23,10 @@ pub fn arch_send_event(cpu_id: u64, _sgi_num: u64) {
     #[cfg(not(feature = "aclint"))]
     sbi_rt::send_ipi(HartMask::from_mask_base(1 << cpu_id, 0));
 }
+
+/// Handle send_ipi event.
+pub fn arch_ipi_handler() {
+    unsafe {
+        riscv_h::register::hvip::set_vssip();
+    }
+}

--- a/src/arch/riscv64/trap.rs
+++ b/src/arch/riscv64/trap.rs
@@ -27,10 +27,10 @@ use crate::memory::{GuestPhysAddr, HostPhysAddr};
 use crate::percpu::this_cpu_data;
 use crate::platform::__board::*;
 use core::arch::{asm, global_asm};
-use riscv::register::mtvec::TrapMode;
-use riscv::register::stvec;
-use riscv::register::{hvip, sie};
+use riscv::register::stvec::TrapMode;
+use riscv::register::{sie, stvec};
 use riscv_decode::Instruction;
+use riscv_h::register::hvip;
 
 extern "C" {
     fn _hyp_trap_vector();
@@ -101,19 +101,24 @@ pub const INS_RS2_MASK: usize = 0x01f00000;
 pub const INS_RD_MASK: usize = 0x00000f80;
 
 pub fn install_trap_vector() {
+    // Set the trap vector.
+    use riscv::register::stvec::Stvec;
+    let mut stvec = Stvec::from_bits(0);
+    stvec.set_address(_hyp_trap_vector as usize);
+    stvec.set_trap_mode(TrapMode::Direct);
     unsafe {
-        // Set the trap vector.
-        stvec::write(_hyp_trap_vector as usize, TrapMode::Direct);
+        stvec::write(stvec);
     }
 }
+
 pub fn sync_exception_handler(current_cpu: &mut ArchCpu) {
     trace!("current_cpu: stack{:#x}", current_cpu.stack_top);
     let trap_code = read_csr!(CSR_SCAUSE);
     trace!("CSR_SCAUSE: {}", trap_code);
     if (read_csr!(CSR_HSTATUS) & (1 << 7)) == 0 {
-        //HSTATUS_SPV
+        // HSTATUS_SPV
         error!("exception from HS mode");
-        //unreachable!();
+        unreachable!();
     }
     let trap_value = read_csr!(CSR_HTVAL);
     trace!("CSR_HTVAL: {:#x}", trap_value);
@@ -141,16 +146,14 @@ pub fn sync_exception_handler(current_cpu: &mut ArchCpu) {
         }
         _ => {
             warn!(
-                "CPU {} trap {},sepc: {:#x}",
-                current_cpu.cpuid, trap_code, current_cpu.sepc
+                "CPU {} sync exception, sepc: {:#x}",
+                current_cpu.cpuid, current_cpu.sepc
             );
             warn!("trap info: {} {:#x} {:#x}", trap_code, trap_value, trap_ins);
             let raw_inst = read_inst(trap_pc);
             let inst = riscv_decode::decode(raw_inst);
             warn!("trap ins: {:#x}  {:?}", raw_inst, inst);
-            // current_cpu.sepc += 4;
-            error!("unhandled trap");
-            current_cpu.idle();
+            panic!("Unhandled sync exception");
         }
     }
 }
@@ -216,7 +219,7 @@ pub fn ins_ldst_decode(ins: usize) -> (usize, bool, bool) {
 pub fn guest_page_fault_handler(current_cpu: &mut ArchCpu) {
     #[cfg(feature = "plic")]
     {
-        use riscv::register::{htinst, htval, stval};
+        use riscv_h::register::{htinst, htval, stval};
         // htval: Hypervisor bad guest physical address.
         let addr: usize = (htval::read() << 2) | (stval::read() & 0x3);
         // htinst: Hypervisor trap instruction (transformed).
@@ -340,6 +343,7 @@ pub fn guest_page_fault_handler(current_cpu: &mut ArchCpu) {
     }
 }
 
+/// Read instruction from guest memory.
 fn read_inst(addr: GuestPhysAddr) -> u32 {
     let mut ins: u32;
     if addr & 0b1 != 0 {
@@ -356,6 +360,8 @@ fn read_inst(addr: GuestPhysAddr) -> u32 {
     ins
 }
 
+/// Hypervisor Virtual-Machine Load and Store Instruction.
+/// HLVX.HU emulate VS load instruction.
 fn hlvxhu(addr: GuestPhysAddr) -> u64 {
     let mut value: u64;
     unsafe {
@@ -383,27 +389,19 @@ fn decode_inst(inst: u32) -> (usize, Option<Instruction>) {
 /// handle external interrupt
 pub fn interrupts_arch_handle(current_cpu: &mut ArchCpu) {
     trace!("interrupts_arch_handle @CPU{}", current_cpu.cpuid);
-    let trap_code: usize;
-    trap_code = read_csr!(CSR_SCAUSE);
-    trace!("CSR_SCAUSE: {:#x}", trap_code);
-    match trap_code & 0xfff {
-        InterruptType::STI => {
-            trace!("STI on CPU{}", current_cpu.cpuid);
-            unsafe {
-                hvip::set_vstip();
-                sie::clear_stimer();
-            }
-            trace!("sip{:#x}", read_csr!(CSR_SIP));
-            trace!("sie {:#x}", read_csr!(CSR_SIE));
-        }
+    let trap_code = unsafe { riscv::register::scause::read().code() };
+    match trap_code {
+        InterruptType::STI => unsafe {
+            hvip::set_vstip();
+            sie::clear_stimer();
+        },
         InterruptType::SSI => {
-            trace!("SSI on CPU {}", current_cpu.cpuid);
             handle_ssi(current_cpu);
+            unsafe {
+                riscv::register::sip::clear_ssoft();
+            }
         }
-        InterruptType::SEI => {
-            debug!("SEI on CPU {}", current_cpu.cpuid);
-            handle_eirq(current_cpu)
-        }
+        InterruptType::SEI => handle_eirq(current_cpu),
         _ => {
             error!(
                 "unhandled trap {:#x},sepc: {:#x}",
@@ -429,28 +427,19 @@ pub fn handle_eirq(current_cpu: &mut ArchCpu) {
         }
 
         // 2. check if this zone belongs this irq.
-        if this_cpu_data()
+        if !this_cpu_data()
             .zone
             .as_ref()
             .unwrap()
             .read()
             .irq_in_zone(irq_id as u32)
-            == false
         {
             error!("irq {} is not belongs to this zone", irq_id);
             return;
         }
 
         // 3. inject hw irq to zone.
-        this_cpu_data()
-            .zone
-            .as_ref()
-            .unwrap()
-            .read()
-            .vplic
-            .as_ref()
-            .unwrap()
-            .inject_irq(pcontext_to_vcontext(context_id), irq_id as usize, true);
+        inject_irq(irq_id as usize, true);
     }
     #[cfg(feature = "aia")]
     {
@@ -458,15 +447,8 @@ pub fn handle_eirq(current_cpu: &mut ArchCpu) {
     }
 }
 
+/// Handle supervisor software interrupt.
 pub fn handle_ssi(current_cpu: &mut ArchCpu) {
-    trace!("handle_ssi");
-    let sip = read_csr!(CSR_SIP);
-    trace!("CPU{} sip: {:#x}", current_cpu.cpuid, sip);
-    clear_csr!(CSR_SIP, 1 << 1);
-    let sip2 = read_csr!(CSR_SIP);
-    trace!("CPU{} sip*: {:#x}", current_cpu.cpuid, sip2);
-
-    trace!("hvip: {:#x}", read_csr!(CSR_HVIP));
-    set_csr!(CSR_HVIP, 1 << 2);
-    check_events();
+    // Get next event to handle.
+    while check_events() {}
 }

--- a/src/arch/riscv64/trap.rs
+++ b/src/arch/riscv64/trap.rs
@@ -134,7 +134,7 @@ pub fn sync_exception_handler(current_cpu: &mut ArchCpu) {
         ExceptionType::ECALL_VS => {
             trace!("ECALL_VS");
             sbi_vs_handler(current_cpu);
-            current_cpu.sepc += 4;          // For ecall, skip the ecall instruction.
+            current_cpu.sepc += 4; // For ecall, skip the ecall instruction.
         }
         ExceptionType::LOAD_GUEST_PAGE_FAULT => {
             trace!("LOAD_GUEST_PAGE_FAULT");
@@ -147,7 +147,10 @@ pub fn sync_exception_handler(current_cpu: &mut ArchCpu) {
         _ => {
             let raw_inst = read_inst(trap_pc);
             let inst = riscv_decode::decode(raw_inst);
-            warn!("CPU {} sync exception, sepc: {:#x}", current_cpu.cpuid, current_cpu.sepc);
+            warn!(
+                "CPU {} sync exception, sepc: {:#x}",
+                current_cpu.cpuid, current_cpu.sepc
+            );
             warn!("Trap cause code: {}", trap_code);
             warn!("htval: {:#x}, htinst: {:#x}", trap_value, trap_ins);
             warn!("trap instruction: {:?}", inst);
@@ -393,7 +396,7 @@ pub fn interrupts_arch_handle(current_cpu: &mut ArchCpu) {
         InterruptType::STI => {
             // Inject timer interrupt to VS.
             handle_timer_interrupt(current_cpu);
-        },
+        }
         InterruptType::SSI => {
             // Get event to handle and clear software interrupt pending bit.
             handle_software_interrupt(current_cpu);
@@ -421,10 +424,12 @@ pub fn handle_timer_interrupt(current_cpu: &mut ArchCpu) {
 
 /// Handle supervisor software interrupt.
 pub fn handle_software_interrupt(current_cpu: &mut ArchCpu) {
-    while check_events() { 
+    while check_events() {
         // Get next event to handle, it is handled in check_events function.
     }
-    unsafe { riscv::register::sip::clear_ssoft(); }
+    unsafe {
+        riscv::register::sip::clear_ssoft();
+    }
 }
 
 /// Handle supervisor external interrupt.
@@ -437,7 +442,9 @@ pub fn handle_external_interrupt(current_cpu: &mut ArchCpu) {
         let irq_id = host_plic().claim(context_id);
 
         // If this irq has been claimed, it will be 0.
-        if irq_id == 0 { return; }
+        if irq_id == 0 {
+            return;
+        }
 
         // 2. inject hw irq to zone.
         inject_irq(irq_id as usize, true);
@@ -447,5 +454,3 @@ pub fn handle_external_interrupt(current_cpu: &mut ArchCpu) {
         panic!("HS extensional interrupt")
     }
 }
-
-

--- a/src/device/irqchip/aia/aplic.rs
+++ b/src/device/irqchip/aia/aplic.rs
@@ -13,14 +13,13 @@
 //
 // Authors:
 //
-use riscv::use_sv32;
+
 use spin::Once;
 use spin::RwLock;
 // use crate::device::irqchip::aia::imsic::imsic_trigger;
 use crate::config::root_zone_config;
 use crate::zone::Zone;
 use crate::{arch::cpu::ArchCpu, memory::GuestPhysAddr, percpu::this_cpu_data};
-use fdt::Fdt;
 use riscv_decode::Instruction;
 // S-mode interrupt delivery controller
 const APLIC_S_IDC: usize = 0xd00_4000;

--- a/src/device/irqchip/plic/mod.rs
+++ b/src/device/irqchip/plic/mod.rs
@@ -30,8 +30,8 @@ use crate::platform::__board::*;
 use crate::zone::Zone;
 use crate::{arch::cpu::ArchCpu, percpu::this_cpu_data};
 use alloc::vec::Vec;
-use riscv::register::hvip;
 use riscv_decode::Instruction;
+use riscv_h::register::hvip;
 use spin::Once;
 
 /*
@@ -67,7 +67,7 @@ pub fn percpu_init() {
 }
 
 pub fn inject_irq(irq: usize, is_hardware: bool) {
-    // warn!("inject_irq: {} is_hardware: {}", irq, is_hardware);
+    debug!("inject_irq: {} is_hardware: {}", irq, is_hardware);
     let vcontext_id = pcontext_to_vcontext(this_cpu_data().id * 2 + 1);
     this_cpu_data()
         .zone
@@ -153,16 +153,28 @@ pub fn update_hart_line() {
 
 impl Zone {
     pub fn arch_irqchip_reset(&self) {
+        // We should make sure only one cpu to do this.
+        // This func will only be called by one root zone's cpu.
         let host_plic = host_plic();
+        let vplic = self.vplic.as_ref().unwrap();
         for (index, &word) in self.irq_bitmap.iter().enumerate() {
             for bit_position in 0..32 {
                 if word & (1 << bit_position) != 0 {
                     let irq_id = index * 32 + bit_position;
+                    // Skip the irq_id which is not in HW_IRQS
+                    if !HW_IRQS.iter().any(|&x| x == irq_id as _) {
+                        continue;
+                    }
                     // Reset priority
+                    info!("Reset irq_id {} priority to 0", irq_id);
                     host_plic.set_priority(irq_id, 0);
                     // Reset enable
                     self.cpu_set.iter().for_each(|cpuid| {
                         let pcontext_id = cpuid * 2 + 1;
+                        info!(
+                            "Reset pcontext_id {} irq_id {} enable to false",
+                            pcontext_id, irq_id
+                        );
                         host_plic.set_enable_num(pcontext_id, irq_id, false);
                     });
                 }
@@ -171,8 +183,10 @@ impl Zone {
         self.cpu_set.iter().for_each(|cpuid| {
             // Reset threshold
             let pcontext_id = cpuid * 2 + 1;
+            info!("Reset pcontext_id {} threshold to 0", pcontext_id);
             host_plic.set_threshold(pcontext_id, 0);
             // At the same time, clear the events related to this cpu.
+            info!("Clear events related to cpu {}", cpuid);
             crate::event::clear_events(cpuid);
         });
     }

--- a/src/device/irqchip/plic/vplic.rs
+++ b/src/device/irqchip/plic/vplic.rs
@@ -77,6 +77,12 @@ impl VirtualPLIC {
         inner.vplic_set_hw(intr_id, hw);
     }
 
+    /// Get one interrupt as hardware interrupt.
+    pub fn vplic_get_hw(&self, intr_id: usize) -> bool {
+        let inner = self.inner.lock();
+        inner.vplic_get_hw(intr_id)
+    }
+
     /// Inject an interrupt into the vPLIC.
     pub fn inject_irq(&self, vcontext_id: usize, intr_id: usize, hw: bool) {
         debug!("Inject interrupt {} to vcontext {}", intr_id, vcontext_id);
@@ -393,11 +399,11 @@ impl VirtualPLICInner {
             let irq_id = self.vplic_get_next_pending(vcontext_id);
             if irq_id != 0 {
                 unsafe {
-                    riscv::register::hvip::set_vseip();
+                    riscv_h::register::hvip::set_vseip();
                 }
             } else {
                 unsafe {
-                    riscv::register::hvip::clear_vseip();
+                    riscv_h::register::hvip::clear_vseip();
                 }
             }
         } else {

--- a/src/device/uart/mod.rs
+++ b/src/device/uart/mod.rs
@@ -31,7 +31,9 @@ mod xuartps;
 pub use xuartps::{console_getchar, console_putchar};
 
 #[cfg(target_arch = "riscv64")]
-pub use crate::arch::riscv64::sbi::{console_getchar, console_putchar};
+pub use crate::arch::riscv64::sbi::{
+    sbi_console_getchar as console_getchar, sbi_console_putchar as console_putchar,
+};
 
 #[cfg(all(feature = "loongson_uart", target_arch = "loongarch64"))]
 mod loongson_uart;

--- a/src/event.rs
+++ b/src/event.rs
@@ -145,7 +145,7 @@ pub fn check_events() -> bool {
         }
         #[cfg(target_arch = "riscv64")]
         Some(IPI_EVENT_SEND_IPI) => {
-            // This event is different form events above, it is used to inject software interrupt.
+            // This event is different from events above, it is used to inject software interrupt.
             // While events above will inject external interrupt.
             use crate::arch::ipi::arch_ipi_handler;
             arch_ipi_handler();

--- a/src/event.rs
+++ b/src/event.rs
@@ -30,6 +30,7 @@ pub const IPI_EVENT_VIRTIO_INJECT_IRQ: usize = 2;
 pub const IPI_EVENT_WAKEUP_VIRTIO_DEVICE: usize = 3;
 pub const IPI_EVENT_CLEAR_INJECT_IRQ: usize = 4;
 pub const IPI_EVENT_UPDATE_HART_LINE: usize = 5;
+pub const IPI_EVENT_SEND_IPI: usize = 6;
 
 static EVENT_MANAGER: Once<EventManager> = Once::new();
 
@@ -140,6 +141,14 @@ pub fn check_events() -> bool {
         Some(IPI_EVENT_UPDATE_HART_LINE) => {
             info!("cpu {} update hart line", cpu_data.id);
             irqchip::plic::update_hart_line();
+            true
+        }
+        #[cfg(target_arch = "riscv64")]
+        Some(IPI_EVENT_SEND_IPI) => {
+            // This event is different form events above, it is used to inject software interrupt.
+            // While events above will inject external interrupt.
+            use crate::arch::ipi::arch_ipi_handler;
+            arch_ipi_handler();
             true
         }
         _ => false,


### PR DESCRIPTION
This Pull Request contains content below:
- Modify the sbi.rs code (we only support BASE, TIME, HSM, SPI, RFNC, HVISOR sbi extension now)
- Modify software interrupt handler (now it use while loop to handle ipi, not only handle one), this is about #135
- Add IPI_EVENT_SEND_IPI, it is different with other IPIs. It inject software interrupt while other events inject external inerrupt