### PR TITLE
Wrap read and write operations on `consts::NCPU` so users won't see unsafe anymore.

### DIFF
--- a/src/arch/aarch64/mm.rs
+++ b/src/arch/aarch64/mm.rs
@@ -17,10 +17,7 @@ use core::sync::atomic::AtomicU32;
 
 use spin::RwLock;
 
-use crate::{
-    arch::Stage2PageTable, consts, error::HvResult, memory::MemorySet,
-    wait_for,
-};
+use crate::{arch::Stage2PageTable, consts, error::HvResult, memory::MemorySet, wait_for};
 
 use super::sysreg::read_sysreg;
 

--- a/src/arch/aarch64/mm.rs
+++ b/src/arch/aarch64/mm.rs
@@ -18,7 +18,7 @@ use core::sync::atomic::AtomicU32;
 use spin::RwLock;
 
 use crate::{
-    arch::Stage2PageTable, consts, consts::MAX_CPU_NUM, error::HvResult, memory::MemorySet,
+    arch::Stage2PageTable, consts, error::HvResult, memory::MemorySet,
     wait_for,
 };
 

--- a/src/arch/aarch64/mm.rs
+++ b/src/arch/aarch64/mm.rs
@@ -18,7 +18,8 @@ use core::sync::atomic::AtomicU32;
 use spin::RwLock;
 
 use crate::{
-    arch::Stage2PageTable, consts::MAX_CPU_NUM, error::HvResult, memory::MemorySet, wait_for,
+    arch::Stage2PageTable, consts, consts::MAX_CPU_NUM, error::HvResult, memory::MemorySet,
+    wait_for,
 };
 
 use super::sysreg::read_sysreg;
@@ -123,28 +124,23 @@ const PARANGE_TABLE: [usize; 6] = [32, 36, 40, 42, 44, 48];
 static MIN_PARANGE: RwLock<u64> = RwLock::new(0x7);
 static PARANGE_OK_CPUS: AtomicU32 = AtomicU32::new(0);
 
-static mut NCPU: usize = 0;
-
-pub fn setup_parange(ncpu: usize) {
-    unsafe {
-        NCPU = ncpu;
-    }
+pub fn setup_parange() {
     let temp_parange = read_sysreg!(id_aa64mmfr0_el1) & 0xf;
     let mut p = MIN_PARANGE.write();
     *p = p.min(temp_parange);
     drop(p);
 
     PARANGE_OK_CPUS.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
-    wait_for(|| PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) < unsafe { NCPU } as _);
+    wait_for(|| PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) < consts::ncpu() as _);
 }
 
 pub fn get_parange() -> u64 {
-    assert!(PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) == unsafe { NCPU } as _);
+    assert!(PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) == consts::ncpu() as _);
     *MIN_PARANGE.read()
 }
 
 pub fn get_parange_bits() -> usize {
-    assert!(PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) == unsafe { NCPU } as _);
+    assert!(PARANGE_OK_CPUS.load(core::sync::atomic::Ordering::SeqCst) == consts::ncpu() as _);
     PARANGE_TABLE[*MIN_PARANGE.read() as usize]
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -45,8 +45,18 @@ pub fn core_end() -> VirtAddr {
     __core_end as _
 }
 
+pub fn ncpu() -> usize {
+    unsafe { NCPU }
+}
+
+pub fn set_ncpu(n: usize) {
+    unsafe {
+        NCPU = n;
+    }
+}
+
 pub fn mem_pool_start() -> VirtAddr {
-    core_end() + unsafe { NCPU } * PER_CPU_SIZE
+    core_end() + ncpu() * PER_CPU_SIZE
 }
 
 pub fn hv_end() -> VirtAddr {

--- a/src/device/irqchip/gicv2/mod.rs
+++ b/src/device/irqchip/gicv2/mod.rs
@@ -70,7 +70,7 @@ pub fn primary_init_early() {
     info!("GicCpuInterface = {:#x?}", GICV2.gicc_base);
     info!("GicHypervisorInterface = {:#x?}", GICV2.gich_base);
     info!("GicVCpuInterface = {:#x?}", GICV2.gicv_base);
-    gic::PENDING_VIRQS.call_once(|| gic::PendingIrqs::new(unsafe { consts::NCPU }));
+    gic::PENDING_VIRQS.call_once(|| gic::PendingIrqs::new(consts::ncpu()));
 }
 
 pub fn percpu_init() {

--- a/src/device/irqchip/gicv3/gicr.rs
+++ b/src/device/irqchip/gicv3/gicr.rs
@@ -94,7 +94,7 @@ impl LpiPropTable {
         let page_num: usize = ((1 << (id_bits + 1)) - 8192) / PAGE_SIZE;
         let f = Frame::new_contiguous(page_num, 0).unwrap();
         let propreg = f.start_paddr() | 0x78f;
-        for id in 0..unsafe { consts::NCPU } {
+        for id in 0..consts::ncpu() {
             let propbaser = host_gicr_base(id) + GICR_PROPBASER;
             unsafe {
                 ptr::write_volatile(propbaser as *mut u64, propreg as _);

--- a/src/device/irqchip/gicv3/mod.rs
+++ b/src/device/irqchip/gicv3/mod.rs
@@ -461,7 +461,7 @@ pub fn primary_init_early() {
         gits_init();
     }
 
-    PENDING_VIRQS.call_once(|| PendingIrqs::new(unsafe { consts::NCPU }));
+    PENDING_VIRQS.call_once(|| PendingIrqs::new(consts::ncpu()));
     debug!("gic = {:#x?}", GIC.get().unwrap());
 }
 

--- a/src/device/irqchip/gicv3/vgic.rs
+++ b/src/device/irqchip/gicv3/vgic.rs
@@ -43,7 +43,7 @@ impl Zone {
         self.mmio_region_register(arch.gicd_base, arch.gicd_size, vgicv3_dist_handler, 0);
         self.mmio_region_register(arch.gits_base, arch.gits_size, vgicv3_its_handler, 0);
 
-        for cpu in 0..unsafe { consts::NCPU } {
+        for cpu in 0..consts::ncpu() {
             let gicr_base = arch.gicr_base + cpu * PER_GICR_SIZE;
             debug!("registering gicr {} at {:#x?}", cpu, gicr_base);
             self.mmio_region_register(gicr_base, PER_GICR_SIZE, vgicv3_redist_handler, cpu);
@@ -153,7 +153,7 @@ pub fn vgicv3_redist_handler(mmio: &mut MMIOAccess, cpu: usize) -> HvResult {
         }
         GICR_TYPER => {
             mmio_perform_access(gicr_base, mmio);
-            if cpu == unsafe { consts::NCPU } - 1 {
+            if cpu == consts::ncpu() - 1 {
                 mmio.value |= GICR_TYPER_LAST;
             }
         }

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -41,7 +41,6 @@ pub static VIRTIO_BRIDGE: Mutex<VirtioBridgeRegion> = Mutex::new(VirtioBridgeReg
 const QUEUE_NOTIFY: usize = 0x50;
 pub const MAX_REQ: u32 = 32;
 pub const MAX_DEVS: usize = 4; // Attention: The max virtio-dev number for vm is 4.
-pub const MAX_CPUS: usize = 4;
 
 #[cfg(not(target_arch = "riscv64"))]
 pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -87,7 +87,7 @@ impl<'a> HyperCall<'a> {
                 HyperCallCode::HvZoneList => self.hv_zone_list(&mut *(arg0 as *mut ZoneInfo), arg1),
                 HyperCallCode::HvClearInjectIrq => {
                     use crate::event::IPI_EVENT_CLEAR_INJECT_IRQ;
-                    for i in 1..unsafe { consts::NCPU } {
+                    for i in 1..consts::ncpu() {
                         // if target cpu status is not running, we skip it
                         if !get_cpu_data(i).arch_cpu.power_on {
                             continue;
@@ -314,7 +314,7 @@ impl<'a> HyperCall<'a> {
             let power_on = get_cpu_data(cpu_id).arch_cpu.power_on;
             count += 1;
             if count > MAX_WAIT_TIMES {
-                if (power_on) {
+                if power_on {
                     error!("cpu {} cannot be shut down", cpu_id);
                     return false;
                 }

--- a/src/ivc.rs
+++ b/src/ivc.rs
@@ -157,7 +157,7 @@ impl Zone {
     pub fn ivc_init(&mut self, ivc_configs: &[HvIvcConfig]) {
         for ivc_config in ivc_configs {
             // is_new is ok to remove
-            if let Ok((is_new, start_paddr)) = insert_ivc_record(ivc_config, self.id as _) {
+            if let Ok((_is_new, start_paddr)) = insert_ivc_record(ivc_config, self.id as _) {
                 info!(
                     "ivc init: zone {}'s shared mem begins at {:x}, ipa is {:x}",
                     self.id, start_paddr, ivc_config.shared_mem_ipa
@@ -231,7 +231,7 @@ pub fn mmio_ivc_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
             let peer_id = rec
                 .peer_infos
                 .iter()
-                .find(|&(peer_id, info)| info.zone_id == zone_id as _)
+                .find(|&(_peer_id, info)| info.zone_id == zone_id as _)
                 .map(|(peer_id, _)| *peer_id)
                 .unwrap();
             peer_id as usize

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,9 +229,7 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
             println!("Using {} cpu(s) on this system.", ncpu);
         }
 
-        unsafe {
-            consts::NCPU = ncpu;
-        }
+        consts::set_ncpu(ncpu);
         wakeup_secondary_cpus(cpu.id, host_dtb, ncpu);
     }
 
@@ -246,7 +244,7 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
     );
 
     #[cfg(target_arch = "aarch64")]
-    setup_parange(ncpu);
+    setup_parange();
 
     if is_primary {
         primary_init_early(ncpu); // create root zone here

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -56,7 +56,7 @@ impl Zone {
             name: name.try_into().unwrap(),
             id: zoneid,
             gpm: new_s2_memory_set(),
-            cpu_set: CpuSet::new(unsafe { consts::NCPU } as usize, 0),
+            cpu_set: CpuSet::new(consts::ncpu(), 0),
             mmio: Vec::new(),
             irq_bitmap: [0; 1024 / 32],
             pciroot: PciRoot::new(),

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -275,7 +275,7 @@ pub struct ZoneInfo {
 }
 // Be careful about dead lock for zone.write()
 pub fn zone_error() {
-    if (is_this_root_zone()) {
+    if is_this_root_zone() {
         panic!("root zone has some error");
     }
     let zone = this_zone();


### PR DESCRIPTION
Wrap read and write operations on `consts::NCPU` so users won't see unsafe anymore.