### PR TITLE
riscv64: support unittest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
           - arch: aarch64
             board: "qemu-gicv2"
             rustc_target: aarch64-unknown-none
+          - arch: riscv64
+            board: "qemu-plic"
+            rustc_target: riscv64gc-unknown-none-elf
+          - arch: riscv64
+            board: "qemu-aia"
+            rustc_target: riscv64gc-unknown-none-elf
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/platform/riscv64/qemu-aia/board.rs
+++ b/platform/riscv64/qemu-aia/board.rs
@@ -21,6 +21,9 @@ pub const BOARD_NCPUS: usize = 4;
 
 pub const ACLINT_SSWI_BASE: usize = 0x2F00000;
 
+// This device is used for qemu-quit.
+pub const SIFIVE_TEST_BASE: u64 = 0x100000;
+
 pub const PLIC_BASE: usize = 0xc000000;
 pub const APLIC_BASE: usize = 0xc000000;
 pub const PLIC_MAX_IRQ: usize = 1024;

--- a/platform/riscv64/qemu-aia/test/runner.sh
+++ b/platform/riscv64/qemu-aia/test/runner.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+PWD=$(pwd)
+THIS=$(basename $0)
+CARGO_BUILD_INPUT_ARG0=$1
+
+# capture env: FEATURES, ARCH
+
+ARCH=${ARCH}
+FEATURES=${FEATURES}
+BOARD=${BOARD}
+
+UBOOT_GICV3=u-boot-atf.bin
+UBOOT_GICV2=u-boot-v2.bin
+
+HVISOR_ELF=$CARGO_BUILD_INPUT_ARG0
+HVISOR_BIN_TMP=$HVISOR_ELF.bin.tmp
+HVISOR_BIN=$HVISOR_ELF.bin
+
+OBJCOPY=rust-objcopy
+
+YELLOW='\033[1;33m'
+END='\033[0m'
+
+info() {
+    # echo "${YELLOW}[INFO | $THIS] $1${END}"
+    echo "[INFO | $THIS] $1"
+}
+
+# check if mkimage is installed
+if ! command -v mkimage &>/dev/null; then
+    if command -v apt &>/dev/null; then
+        sudo apt update && sudo apt install -y u-boot-tools
+    elif command -v brew &>/dev/null; then
+        brew install u-boot-tools
+    else
+        info "You need to install u-boot-tools to run this script (mkimage)"
+        exit 1
+    fi
+fi
+
+info "Running cargo test with env: ARCH=$ARCH, FEATURES=$FEATURES, BOARD=$BOARD"
+
+info "Building hvisor with $CARGO_BUILD_INPUT_ARG0"
+info "PWD=$PWD, running cargo test"
+$OBJCOPY $HVISOR_ELF --strip-all -O binary $HVISOR_BIN_TMP
+
+if [ "$ARCH" == "aarch64" ]; then
+    mkimage -n hvisor_img -A arm64 -O linux -C none -T kernel -a 0x40400000 \
+        -e 0x40400000 -d $HVISOR_BIN_TMP $HVISOR_BIN
+
+    info "Running QEMU with $HVISOR_BIN"
+
+    # if we have gicv2,gicv3 in FEATURES, we get the number from it
+    AARCH64_GIC_TEST_VERSION=3
+    if [[ $FEATURES == *"gicv2"* ]]; then
+        AARCH64_GIC_TEST_VERSION=2
+    fi
+    info "Using GIC version: $AARCH64_GIC_TEST_VERSION"
+
+    UBOOT=$UBOOT_GICV3
+    if [ $AARCH64_GIC_TEST_VERSION -eq 2 ]; then
+        UBOOT=$UBOOT_GICV2
+    fi
+    UBOOT=$PWD/platform/$ARCH/$BOARD/image/bootloader/$UBOOT
+    info "Using U-Boot: $UBOOT"
+
+
+    qemu-system-aarch64 \
+        -machine virt,secure=on,gic-version=${AARCH64_GIC_TEST_VERSION},virtualization=on,iommu=smmuv3 \
+        -cpu cortex-a57 -smp 4 -m 3G -nographic \
+        -semihosting \
+        -bios $UBOOT \
+        -drive if=pflash,format=raw,index=1,file=flash.img \
+        -device loader,file=$HVISOR_BIN,addr=0x40400000,force-raw=on \
+        -global arm-smmuv3.stage=2
+
+    exit 0
+elif [ "$ARCH" == "riscv64" ]; then
+    mv $HVISOR_BIN_TMP $HVISOR_BIN
+    
+    QEMU_MACHINE="virt,aclint=on"
+    if [[ $FEATURES == *"aia"* ]]; then
+        QEMU_MACHINE="virt,aia=aplic-imsic,aia-guests=1,aclint=on"
+    fi
+
+    qemu-system-riscv64 \
+        -machine ${QEMU_MACHINE} \
+        -bios default -cpu rv64 -smp 4 -m 4G -nographic \
+        -kernel $HVISOR_BIN
+
+    exit 0
+else
+    info "Unsupported ARCH: $ARCH"
+    exit 1
+fi

--- a/platform/riscv64/qemu-aia/test/runner.sh
+++ b/platform/riscv64/qemu-aia/test/runner.sh
@@ -12,11 +12,7 @@ ARCH=${ARCH}
 FEATURES=${FEATURES}
 BOARD=${BOARD}
 
-UBOOT_GICV3=u-boot-atf.bin
-UBOOT_GICV2=u-boot-v2.bin
-
 HVISOR_ELF=$CARGO_BUILD_INPUT_ARG0
-HVISOR_BIN_TMP=$HVISOR_ELF.bin.tmp
 HVISOR_BIN=$HVISOR_ELF.bin
 
 OBJCOPY=rust-objcopy
@@ -29,70 +25,15 @@ info() {
     echo "[INFO | $THIS] $1"
 }
 
-# check if mkimage is installed
-if ! command -v mkimage &>/dev/null; then
-    if command -v apt &>/dev/null; then
-        sudo apt update && sudo apt install -y u-boot-tools
-    elif command -v brew &>/dev/null; then
-        brew install u-boot-tools
-    else
-        info "You need to install u-boot-tools to run this script (mkimage)"
-        exit 1
-    fi
-fi
-
 info "Running cargo test with env: ARCH=$ARCH, FEATURES=$FEATURES, BOARD=$BOARD"
 
 info "Building hvisor with $CARGO_BUILD_INPUT_ARG0"
 info "PWD=$PWD, running cargo test"
-$OBJCOPY $HVISOR_ELF --strip-all -O binary $HVISOR_BIN_TMP
+$OBJCOPY $HVISOR_ELF --strip-all -O binary $HVISOR_BIN
 
-if [ "$ARCH" == "aarch64" ]; then
-    mkimage -n hvisor_img -A arm64 -O linux -C none -T kernel -a 0x40400000 \
-        -e 0x40400000 -d $HVISOR_BIN_TMP $HVISOR_BIN
+qemu-system-riscv64 \
+    -machine virt,aia=aplic-imsic,aia-guests=1,aclint=on \
+    -bios default -cpu rv64 -smp 4 -m 4G -nographic \
+    -kernel $HVISOR_BIN
 
-    info "Running QEMU with $HVISOR_BIN"
-
-    # if we have gicv2,gicv3 in FEATURES, we get the number from it
-    AARCH64_GIC_TEST_VERSION=3
-    if [[ $FEATURES == *"gicv2"* ]]; then
-        AARCH64_GIC_TEST_VERSION=2
-    fi
-    info "Using GIC version: $AARCH64_GIC_TEST_VERSION"
-
-    UBOOT=$UBOOT_GICV3
-    if [ $AARCH64_GIC_TEST_VERSION -eq 2 ]; then
-        UBOOT=$UBOOT_GICV2
-    fi
-    UBOOT=$PWD/platform/$ARCH/$BOARD/image/bootloader/$UBOOT
-    info "Using U-Boot: $UBOOT"
-
-
-    qemu-system-aarch64 \
-        -machine virt,secure=on,gic-version=${AARCH64_GIC_TEST_VERSION},virtualization=on,iommu=smmuv3 \
-        -cpu cortex-a57 -smp 4 -m 3G -nographic \
-        -semihosting \
-        -bios $UBOOT \
-        -drive if=pflash,format=raw,index=1,file=flash.img \
-        -device loader,file=$HVISOR_BIN,addr=0x40400000,force-raw=on \
-        -global arm-smmuv3.stage=2
-
-    exit 0
-elif [ "$ARCH" == "riscv64" ]; then
-    mv $HVISOR_BIN_TMP $HVISOR_BIN
-    
-    QEMU_MACHINE="virt,aclint=on"
-    if [[ $FEATURES == *"aia"* ]]; then
-        QEMU_MACHINE="virt,aia=aplic-imsic,aia-guests=1,aclint=on"
-    fi
-
-    qemu-system-riscv64 \
-        -machine ${QEMU_MACHINE} \
-        -bios default -cpu rv64 -smp 4 -m 4G -nographic \
-        -kernel $HVISOR_BIN
-
-    exit 0
-else
-    info "Unsupported ARCH: $ARCH"
-    exit 1
-fi
+exit 0

--- a/platform/riscv64/qemu-plic/board.rs
+++ b/platform/riscv64/qemu-plic/board.rs
@@ -23,7 +23,11 @@ pub const BOARD_NCPUS: usize = 4;
 pub const ACLINT_SSWI_BASE: usize = 0x2F00000;
 
 pub const PLIC_BASE: usize = 0xc000000;
-pub const BOARD_PLIC_INTERRUPTS_NUM: usize = 1023;  // except irq 0
+
+pub const BOARD_PLIC_INTERRUPTS_NUM: usize = 1023; // except irq 0
+
+// This device is used for qemu-quit.
+pub const SIFIVE_TEST_BASE: u64 = 0x100000;
 
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;

--- a/platform/riscv64/qemu-plic/test/runner.sh
+++ b/platform/riscv64/qemu-plic/test/runner.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+PWD=$(pwd)
+THIS=$(basename $0)
+CARGO_BUILD_INPUT_ARG0=$1
+
+# capture env: FEATURES, ARCH
+
+ARCH=${ARCH}
+FEATURES=${FEATURES}
+BOARD=${BOARD}
+
+UBOOT_GICV3=u-boot-atf.bin
+UBOOT_GICV2=u-boot-v2.bin
+
+HVISOR_ELF=$CARGO_BUILD_INPUT_ARG0
+HVISOR_BIN_TMP=$HVISOR_ELF.bin.tmp
+HVISOR_BIN=$HVISOR_ELF.bin
+
+OBJCOPY=rust-objcopy
+
+YELLOW='\033[1;33m'
+END='\033[0m'
+
+info() {
+    # echo "${YELLOW}[INFO | $THIS] $1${END}"
+    echo "[INFO | $THIS] $1"
+}
+
+# check if mkimage is installed
+if ! command -v mkimage &>/dev/null; then
+    if command -v apt &>/dev/null; then
+        sudo apt update && sudo apt install -y u-boot-tools
+    elif command -v brew &>/dev/null; then
+        brew install u-boot-tools
+    else
+        info "You need to install u-boot-tools to run this script (mkimage)"
+        exit 1
+    fi
+fi
+
+info "Running cargo test with env: ARCH=$ARCH, FEATURES=$FEATURES, BOARD=$BOARD"
+
+info "Building hvisor with $CARGO_BUILD_INPUT_ARG0"
+info "PWD=$PWD, running cargo test"
+$OBJCOPY $HVISOR_ELF --strip-all -O binary $HVISOR_BIN_TMP
+
+if [ "$ARCH" == "aarch64" ]; then
+    mkimage -n hvisor_img -A arm64 -O linux -C none -T kernel -a 0x40400000 \
+        -e 0x40400000 -d $HVISOR_BIN_TMP $HVISOR_BIN
+
+    info "Running QEMU with $HVISOR_BIN"
+
+    # if we have gicv2,gicv3 in FEATURES, we get the number from it
+    AARCH64_GIC_TEST_VERSION=3
+    if [[ $FEATURES == *"gicv2"* ]]; then
+        AARCH64_GIC_TEST_VERSION=2
+    fi
+    info "Using GIC version: $AARCH64_GIC_TEST_VERSION"
+
+    UBOOT=$UBOOT_GICV3
+    if [ $AARCH64_GIC_TEST_VERSION -eq 2 ]; then
+        UBOOT=$UBOOT_GICV2
+    fi
+    UBOOT=$PWD/platform/$ARCH/$BOARD/image/bootloader/$UBOOT
+    info "Using U-Boot: $UBOOT"
+
+
+    qemu-system-aarch64 \
+        -machine virt,secure=on,gic-version=${AARCH64_GIC_TEST_VERSION},virtualization=on,iommu=smmuv3 \
+        -cpu cortex-a57 -smp 4 -m 3G -nographic \
+        -semihosting \
+        -bios $UBOOT \
+        -drive if=pflash,format=raw,index=1,file=flash.img \
+        -device loader,file=$HVISOR_BIN,addr=0x40400000,force-raw=on \
+        -global arm-smmuv3.stage=2
+
+    exit 0
+elif [ "$ARCH" == "riscv64" ]; then
+    mv $HVISOR_BIN_TMP $HVISOR_BIN
+    
+    QEMU_MACHINE="virt,aclint=on"
+    if [[ $FEATURES == *"aia"* ]]; then
+        QEMU_MACHINE="virt,aia=aplic-imsic,aia-guests=1,aclint=on"
+    fi
+
+    qemu-system-riscv64 \
+        -machine ${QEMU_MACHINE} \
+        -bios default -cpu rv64 -smp 4 -m 4G -nographic \
+        -kernel $HVISOR_BIN
+
+    exit 0
+else
+    info "Unsupported ARCH: $ARCH"
+    exit 1
+fi


### PR DESCRIPTION
I have ported unittest to riscv64.
Use `make BID=riscv64/qemu-plic test`, (platform qemu-aia also works) then you can get this:
![image](https://github.com/user-attachments/assets/ae931871-117b-48ca-9fa4-6481bc9b6462)
