### PR TITLE
riscv64: handle guest page fault with htinst is zero

### DIFF
--- a/src/arch/riscv64/trap.rs
+++ b/src/arch/riscv64/trap.rs
@@ -293,7 +293,7 @@ pub fn guest_page_fault_handler(current_cpu: &mut ArchCpu) {
             address: addr as _,
             size: size as _,
             is_write: is_write as _,
-            value: if is_write { current_cpu.x[reg] as _} else { 0 },
+            value: if is_write { current_cpu.x[reg] as _ } else { 0 },
         };
 
         match mmio_handle_access(&mut mmio_access) {
@@ -305,7 +305,8 @@ pub fn guest_page_fault_handler(current_cpu: &mut ArchCpu) {
                         // for load instruction, x[rd] will be written.
                         if sign_ext {
                             // note: this is used for 64bit system.
-                            (((mmio_access.value << (64 - 8 * size)) as i64) >> (64 - 8 * size)) as usize
+                            (((mmio_access.value << (64 - 8 * size)) as i64) >> (64 - 8 * size))
+                                as usize
                         } else {
                             mmio_access.value
                         }

--- a/src/arch/riscv64/trap.rs
+++ b/src/arch/riscv64/trap.rs
@@ -177,24 +177,24 @@ pub fn ins_is_preudo(ins: usize) -> bool {
 }
 
 /// Decode instruction to mmio access information.
-pub fn ins_ldst_decode(ins: usize) -> (usize, bool, bool) {
-    /*
-     * For htinst
-     * Standard compressed instruction will expand to 32-bit equivalent instruction.
-     * Due to we don't read instruction from guest memory,
-     * So it will never be compressed instruction here.
-     */
-
+pub fn ins_ldst_decode(ins: usize) -> (usize, bool, bool, usize) {
     if ins_is_compressed(ins) {
-        panic!("trap instruction is compressed.");
-        // if (ins & (INS_C_OPCODE_MASK|INS_C_FUNCT3_MASK) != INS_C_LW) && (ins & (INS_C_OPCODE_MASK|INS_C_FUNCT3_MASK) != INS_C_SW) {
-        //     panic!("trap instruction is not C.LW or C.SW, inst 0x{:04x}.", ins);
-        // }
-        // let size: usize = 4;
-        // let is_write = ins & (INS_C_OPCODE_MASK|INS_C_FUNCT3_MASK) == INS_C_SW;
-        // (size, is_write, true)
+        // Only instruction from memory could be a compressed instruction.
+        // Here, for compressed instruction, only C.LW and C.SW are supported.
+        let ins_is_clw = ins & (INS_C_OPCODE_MASK | INS_C_FUNCT3_MASK) == INS_C_LW;
+        let ins_is_csw = ins & (INS_C_OPCODE_MASK | INS_C_FUNCT3_MASK) == INS_C_SW;
+        if (ins_is_clw == false) && (ins_is_csw == false) {
+            panic!("trap instruction is not C.LW or C.SW, inst 0x{:04x}.", ins);
+        }
+        let is_write = ins_is_csw;
+        // Decode register number.
+        let reg = ((ins >> 2) & 0x7) + 8;
+        (4, is_write, true, reg)
     } else {
-        if (ins & INS_OPCODE_MASK != OPCODE_LOAD) && (ins & INS_OPCODE_MASK != OPCODE_STORE) {
+        let ins_is_load = ins & INS_OPCODE_MASK == OPCODE_LOAD;
+        let ins_is_store = ins & INS_OPCODE_MASK == OPCODE_STORE;
+        // Here, only support standard load/store instruction.
+        if (ins_is_load == false) && (ins_is_store == false) {
             panic!("trap instruction is not Load or Store, inst 0x{:08x}.", ins);
         }
         let funct3: usize = (ins & INS_FUNCT3_MASK) >> 12;
@@ -211,9 +211,16 @@ pub fn ins_ldst_decode(ins: usize) -> (usize, bool, bool) {
                 panic!("trap instruction's funct3 is INVALID, inst 0x{:08x}.", ins);
             }
         };
-        let is_write = ins & INS_OPCODE_MASK == OPCODE_STORE;
+        let is_write = ins_is_store;
+        let reg = if is_write {
+            // For store instruction, rs2 is used as the source register.
+            (INS_RS2_MASK & ins) >> 20
+        } else {
+            // For load instruction, rd is used as the destination register.
+            (INS_RD_MASK & ins) >> 7
+        };
         let sign_ext = (funct3 & 0x4) == 0;
-        (size, is_write, sign_ext)
+        (size, is_write, sign_ext, reg)
     }
 }
 
@@ -226,86 +233,92 @@ pub fn guest_page_fault_handler(current_cpu: &mut ArchCpu) {
         let addr: usize = (htval::read() << 2) | (stval::read() & 0x3);
         // htinst: Hypervisor trap instruction (transformed).
         let mut trap_ins = htinst::read();
+        // Default instruction size is 4 bytes.
+        let mut ins_size = 4;
 
         /*
-         * For a standard compressed instruction (16-bit size), the transformed instruction is found as follows:
-         * 1. Expand the compressed instruction to its 32-bit equivalent.
-         * 2. Transform the 32-bit equivalent instruction.
-         * 3. Replace bit 1 with a 0.
-         *
-         * Bits[1:0] of a transformed standard instruction will be binary 01
-         * if the trapping instruction is compressed and 11 if not.
+         * According riscv spec, htinst is one of the following:
+         *     1. zero;
+         *     2. a transformation of the trapping instruction;
+         *     3. a custom value;
+         *     4. a special pseudoinstruction.
          */
-        let ins_size = match trap_ins & 0x3 {
-            0x1 => 2,
-            0x3 => 4,
-            _ => panic!("Invalid instruction size."),
-        };
-        current_cpu.sepc += ins_size;
 
-        /* Determine trapped instruction */
-        if trap_ins & 0x1 == 0x1 {
+        if trap_ins == 0 {
             /*
-             * Bit[0] == 1, and replacing bit 1 with 1 makes the value
-             * into a valid encoding of a standard instruction.
+             * An implementation may at any time reduce its effort by substituting zero in place of the transformed instruction.
+             * Handling this case is important to be more compatible with different hardware.
              */
-            trap_ins = trap_ins | 0x2;
+            // Get trap instruction from memory.
+            trap_ins = read_inst(current_cpu.sepc) as _;
+            if ins_is_compressed(trap_ins as _) {
+                ins_size = 2;
+            } else {
+                ins_size = 4;
+            }
         } else if ins_is_preudo(trap_ins) {
             /*
-             * htinst's value is one of the special pseudoinstructions
-             * all of which have bits 1:0 equal to 00.
+             * If the instruction is a pseudo instruction, it will be transformed to a standard instruction.
+             * The pseudo instruction will be replaced with a standard instruction.
              */
             panic!("No support for htinst pseudo instruction.");
         } else {
             /*
-             * Bit[0] == 0 implies trapped instruction value is
-             * zero or special value.
+             * For a standard compressed instruction (16-bit size), the transformed instruction is found as follows:
+             *     1. Expand the compressed instruction to its 32-bit equivalent.
+             *     2. Transform the 32-bit equivalent instruction.
+             *     3. Replace bit 1 with a 0.
+             *
+             * RISCV Spec: Bits[1:0] of a transformed standard instruction will be binary 01
+             *     if the trapping instruction is compressed and 11 if not.
              */
-            panic!("No support for reading instruction from guest memory.");
+            ins_size = match trap_ins & 0x3 {
+                0x1 => 2,
+                0x3 => 4,
+                _ => panic!("Invalid instruction size."),
+            };
+            /*
+             * Bit[0] == 1, and replacing bit 1 with 1 makes the value
+             *     into a valid encoding of a standard instruction.
+             */
+            trap_ins = trap_ins | 0x2;
         }
 
-        // decode instruction to get size, is_write and sign_ext.
-        let (size, is_write, sign_ext) = ins_ldst_decode(trap_ins);
-        let ins_rd = (INS_RD_MASK & trap_ins) >> 7;
-        let ins_rs2 = (INS_RS2_MASK & trap_ins) >> 20;
-
-        // warn!("guest page fault at {:#x}, trap_ins: {:08x}, size: {}, is_write: {}, sign_ext: {}", addr, trap_ins, size, is_write, sign_ext);
+        // Decode instruction to get size, is_write, sign_ext and register number.
+        // For load, reg is rd, and for store, reg is rs2.
+        let (size, is_write, sign_ext, reg) = ins_ldst_decode(trap_ins);
 
         // create mmio access struct.
         let mut mmio_access = MMIOAccess {
             address: addr as _,
             size: size as _,
             is_write: is_write as _,
-            value: if is_write {
-                // for store instruction, x[rs2] will be written into memory.
-                if ins_rs2 == 0 {
-                    0
-                } else {
-                    current_cpu.x[ins_rs2] as _
-                }
-            } else {
-                // for load instruction, value is used to store the result.
-                0
-            },
+            value: if is_write { current_cpu.x[reg] as _} else { 0 },
         };
 
         match mmio_handle_access(&mut mmio_access) {
             Ok(_) => {
-                if !is_write && ins_rd != 0 {
-                    // for load instruction, x[rd] will be written.
-                    if sign_ext {
-                        // note: this is used for 64bit system.
-                        mmio_access.value = (((mmio_access.value << (64 - 8 * size)) as i64)
-                            >> (64 - 8 * size))
-                            as usize;
-                    }
-                    current_cpu.x[ins_rd] = mmio_access.value as _;
+                if !is_write {
+                    current_cpu.x[reg] = if reg == 0 {
+                        0
+                    } else {
+                        // for load instruction, x[rd] will be written.
+                        if sign_ext {
+                            // note: this is used for 64bit system.
+                            (((mmio_access.value << (64 - 8 * size)) as i64) >> (64 - 8 * size)) as usize
+                        } else {
+                            mmio_access.value
+                        }
+                    };
                 }
             }
             Err(e) => {
                 panic!("mmio_handle_access: {:#x?}", e);
             }
         }
+        debug!("guest page fault at {:#x}, trap_ins: {:08x}, size: {}, is_write: {}, sign_ext: {}, reg: {}", addr, trap_ins, size, is_write, sign_ext, reg);
+        // Add inst size.
+        current_cpu.sepc += ins_size;
     }
     #[cfg(feature = "aia")]
     {

--- a/src/device/irqchip/plic/vplic.rs
+++ b/src/device/irqchip/plic/vplic.rs
@@ -133,7 +133,10 @@ impl VirtualPLIC {
             return 0;
         }
         if value > u32::MAX as usize {
-            error!("vplic_emul_access: value{:#x} is out of range 0xffffffff", value);
+            error!(
+                "vplic_emul_access: value{:#x} is out of range 0xffffffff",
+                value
+            );
             return 0;
         }
 

--- a/src/device/irqchip/plic/vplic.rs
+++ b/src/device/irqchip/plic/vplic.rs
@@ -134,7 +134,7 @@ impl VirtualPLIC {
         }
         if value > u32::MAX as usize {
             error!(
-                "vplic_emul_access: value{:#x} is out of range 0xffffffff",
+                "vplic_emul_access: value {:#x} is out of range 0xffffffff",
                 value
             );
             return 0;

--- a/src/device/irqchip/plic/vplic.rs
+++ b/src/device/irqchip/plic/vplic.rs
@@ -133,7 +133,7 @@ impl VirtualPLIC {
             return 0;
         }
         if value > u32::MAX as usize {
-            error!("vplic_emul_access: value is out of range");
+            error!("vplic_emul_access: value{:#x} is out of range 0xffffffff", value);
             return 0;
         }
 
@@ -213,6 +213,7 @@ impl VirtualPLIC {
                 let irq_end = bits + 31;
                 let mut inner = self.inner.lock();
                 if is_write {
+                    info!("enable value:{:#x}", value);
                     for irq in irq_start..=irq_end.min(self.max_interrupts) {
                         let irq_enable = (value & (1 << (irq - irq_start))) != 0;
                         if inner.enable[vcontext_id][irq] == irq_enable {

--- a/src/device/irqchip/plic/vplic.rs
+++ b/src/device/irqchip/plic/vplic.rs
@@ -216,7 +216,10 @@ impl VirtualPLIC {
                 let irq_end = bits + 31;
                 let mut inner = self.inner.lock();
                 if is_write {
-                    info!("enable value:{:#x}", value);
+                    debug!(
+                        "vplic_enable_access: vcontext {} irq range {}-{} enable value:{:#x}",
+                        vcontext_id, irq_start, irq_end, value
+                    );
                     for irq in irq_start..=irq_end.min(self.max_interrupts) {
                         let irq_enable = (value & (1 << (irq - irq_start))) != 0;
                         if inner.enable[vcontext_id][irq] == irq_enable {


### PR DESCRIPTION
In #161, I have talked about this.
Hvisor must correctly handle this case in which guest page fault occurs and htinst is zero.
According to riscv spec, hardware could choose to always set htinst to 0.

In qemu 9.2.0, htinst will be filled with a transformed instruction.
In qemu 7.2.0, htinst will be filled with zero.