### PR TITLE
RK3588: Add nop inst to get rid of boot failure

### DIFF
--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -33,6 +33,7 @@ pub unsafe extern "C" fn arch_entry() -> i32 {
             * offset in the binary layout. */
 
             nop
+            nop
             bl {boot_cpuid_get}
 
             adrp x2, __core_end          // x2 = &__core_end


### PR DESCRIPTION
[RK3588: Add nop inst to get rid of boot failure](https://github.com/syswonder/hvisor/commit/2d72ced6dcf85e8377eaac97821fca7eaa592809)