### PR TITLE
riscv64: mv clear_bss to entry assembly code Fix #179

### DIFF
--- a/src/arch/riscv64/entry.rs
+++ b/src/arch/riscv64/entry.rs
@@ -42,6 +42,7 @@ pub unsafe extern "C" fn arch_entry() -> i32 {
         j     0b
     2:
         la    t3, CPU0_BSS_LOCK  // complete bss clear
+        fence w, w               // ensure sw zero, 0(t3) after clear_bss
         sw    zero, 0(t3)
         j     3f
     1:

--- a/src/arch/riscv64/entry.rs
+++ b/src/arch/riscv64/entry.rs
@@ -15,6 +15,10 @@
 //
 use crate::consts::PER_CPU_SIZE;
 
+#[no_mangle]
+#[link_section = ".data"]
+pub static mut CPU0_BSS_LOCK: u32 = 1;
+
 #[naked]
 #[no_mangle]
 #[link_section = ".text.entry"]
@@ -22,12 +26,33 @@ pub unsafe extern "C" fn arch_entry() -> i32 {
     //a0=cpuid,a1=dtb addr
     core::arch::asm!(
         "
-        la t0, __core_end                // t0 = core_end
-        li t1, {per_cpu_size}            // t1 = per_cpu_size
-        mul t2, a0, t1                   // t2 = cpuid * per_cpu_size
-        add t2, t1, t2                   // t2 = cpuid * per_cpu_size+per_cpu_size
-        add sp, t0, t2                   // sp = core_end + cpuid * per_cpu_size + per_cpu_size
-        call {rust_main}
+        la t0, __core_end        // t0 = core_end
+        li t1, {per_cpu_size}    // t1 = per_cpu_size
+        mul t2, a0, t1           // t2 = cpuid * per_cpu_size
+        add t2, t1, t2           // t2 = cpuid * per_cpu_size+per_cpu_size
+        add sp, t0, t2           // sp = core_end + cpuid * per_cpu_size + per_cpu_size
+
+        bnez  a0, 1f             // if cpuid != 0, jump to wait
+        la    a3, sbss           // a3 = bss's start addr
+        la    a4, ebss           // a4 = bss's end addr
+    0:
+        blt   a4, a3, 2f         // cpu0 clear bss
+        sb    zero, 0(a3)
+        addi  a3, a3, 1
+        j     0b
+    2:
+        la    t3, CPU0_BSS_LOCK  // complete bss clear
+        sw    zero, 0(t3)
+        j     3f
+    1:
+        la    t3, CPU0_BSS_LOCK
+    3:
+        lw    t4, 0(t3)          // wait for CPU0 to clear bss
+        bnez  t4, 3b
+
+        fence rw, rw             // ensure all cores can see the bss cleared 
+
+        call {rust_main}         // a0, a1, sp are certain values
         ",
         rust_main = sym crate::rust_main,
         per_cpu_size=const PER_CPU_SIZE,

--- a/src/arch/riscv64/entry.rs
+++ b/src/arch/riscv64/entry.rs
@@ -51,7 +51,8 @@ pub unsafe extern "C" fn arch_entry() -> i32 {
         lw    t4, 0(t3)          // wait for CPU0 to clear bss
         bnez  t4, 3b
 
-        fence rw, rw             // ensure all cores can see the bss cleared 
+        fence r, rw              // ensure all cores can see the bss cleared
+                                 // prevent cpus to read/write uncleared bss
 
         call {rust_main}         // a0, a1, sp are certain values
         ",

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,6 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
     if MASTER_CPU.load(Ordering::Acquire) == -1 {
         MASTER_CPU.store(cpuid as i32, Ordering::Release);
         is_primary = true;
-        #[cfg(target_arch = "riscv64")]
-        clear_bss();
         memory::heap::init();
         memory::heap::test();
     }


### PR DESCRIPTION
This PR is to fix #179.

Mv clear_bss function before println, because println uses PRINT_LOCK which is in bss segment.

I use cpu0 to clear_bss, it could see cleared bss segment sure.

In order to let other cores could see cleared bss, I use `fence rw, rw` to ensure other cores run into rust_main after seeing cleared bss segment.