### PR TITLE
Update configuration for aarch64/qemu-gicv2 and aarch64/qemu-gicv3

### DIFF
--- a/platform/aarch64/qemu-gicv2/configs/zone1-linux-virtio.json
+++ b/platform/aarch64/qemu-gicv2/configs/zone1-linux-virtio.json
@@ -1,0 +1,31 @@
+{
+  "zones": [
+    {
+      "id": 1,
+      "memory_region": [
+        {
+          "zone0_ipa": "0x50000000",
+          "zonex_ipa": "0x50000000",
+          "size": "0x30000000"
+        }
+      ],
+      "devices": [
+        {
+          "type": "console",
+          "addr": "0xa003a00",
+          "len": "0x200",
+          "irq": 76,
+          "status": "enable"
+        },
+        {
+          "type": "blk",
+          "addr": "0xa003e00",
+          "len": "0x200",
+          "irq": 78,
+          "img": "zone1-linux-rootfs.ext4",
+          "status": "enable"
+        }
+      ]
+    }
+  ]
+}

--- a/platform/aarch64/qemu-gicv2/configs/zone1-linux.json
+++ b/platform/aarch64/qemu-gicv2/configs/zone1-linux.json
@@ -1,0 +1,52 @@
+{
+  "arch": "arm64",
+  "name": "zone1-linux",
+  "zone_id": 1,
+  "cpus": [
+    2,
+    3
+  ],
+  "memory_regions": [
+    {
+      "type": "ram",
+      "physical_start": "0x50000000",
+      "virtual_start": "0x50000000",
+      "size": "0x30000000"
+    },
+    {
+      "type": "virtio",
+      "physical_start": "0xa003a00",
+      "virtual_start": "0xa003a00",
+      "size": "0x200"
+    },
+    {
+      "type": "virtio",
+      "physical_start": "0xa003e00",
+      "virtual_start": "0xa003e00",
+      "size": "0x200"
+    }
+  ],
+  "interrupts": [
+    76,
+    78
+  ],
+  "ivc_configs": [],
+  "kernel_filepath": "zone1-linux-kernel",
+  "kernel_args": "",
+  "dtb_filepath": "zone1-linux.dtb",
+  "kernel_load_paddr": "0x50400000",
+  "dtb_load_paddr": "0x50000000",
+  "entry_point": "0x50400000",
+  "arch_config": {
+    "gic_version": "v2",
+    "gicd_base": "0x8000000",
+    "gicd_size": "0x10000",
+    "gicc_base": "0x8010000",
+    "gicc_size": "0x10000",
+    "gicc_offset": "0x0",
+    "gich_base": "0x8030000",
+    "gich_size": "0x10000",
+    "gicv_base": "0x8040000",
+    "gicv_size": "0x10000"
+  }
+}

--- a/platform/aarch64/qemu-gicv2/image/dts/zone0.dts
+++ b/platform/aarch64/qemu-gicv2/image/dts/zone0.dts
@@ -35,7 +35,18 @@
 
 	memory@50000000 {
 		device_type = "memory";
-		reg = <0x00 0x50000000 0x00 0x80000000>;
+		reg = <0x00 0x50000000 0x00 0x70000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		ranges;
+
+		nonroot@50000000 {
+			no-map;
+			reg = <0x00 0x50000000 0x00 0x30000000>;
+		};
 	};
 
 	intc@8000000 {
@@ -91,7 +102,13 @@
 	};
 
 	chosen {
-		bootargs = "earlycon console=ttyAMA0 root=/dev/vda mem=768M rw";
+		bootargs = "clk_ignore_unused earlycon console=ttyAMA0 root=/dev/vda iomem=relaxed rw";
 		stdout-path = "/pl011@9000000";
+	};
+
+	hvisor_virtio_device {
+		compatible = "hvisor";
+		interrupt-parent = <0x01>;
+		interrupts = <0x00 0x20 0x01>;
 	};
 };

--- a/platform/aarch64/qemu-gicv2/image/dts/zone1-linux.dts
+++ b/platform/aarch64/qemu-gicv2/image/dts/zone1-linux.dts
@@ -1,0 +1,84 @@
+/dts-v1/;
+
+/ {
+	#size-cells = <0x02>;
+	#address-cells = <0x02>;
+	interrupt-parent = <0x01>;
+	model = "linux,dummy-virt";
+	compatible = "linux,dummy-virt";
+
+	cpus {
+		#size-cells = <0x00>;
+		#address-cells = <0x01>;
+
+		cpu@2 {
+			reg = <0x02>;
+			enable-method = "psci";
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+		};
+
+		cpu@3 {
+			reg = <0x03>;
+			enable-method = "psci";
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+
+	memory@50000000 {
+		device_type = "memory";
+		reg = <0x0 0x50000000 0x0 0x30000000>;
+	};
+
+	gic@8000000 {
+		phandle = <0x01>;
+		reg = <0x00 0x8000000 0x00 0x10000 0x00 0x8010000 0x00 0x10000 0x00 0x8030000 0x00 0x10000 0x00 0x8040000 0x00 0x10000>;
+		compatible = "arm,cortex-a15-gic";
+		interrupt-controller;
+		#interrupt-cells = <0x03>;
+	};
+
+	apb-pclk {
+		phandle = <0x8000>;
+		clock-output-names = "clk24mhz";
+		clock-frequency = <0x16e3600>;
+		#clock-cells = <0x00>;
+		compatible = "fixed-clock";
+	};
+
+	timer {
+		interrupt-parent = <0x01>;
+		interrupts = <0x01 0x0d 0xf04 0x01 0x0e 0xf04 0x01 0x0b 0xf04 0x01 0x0a 0xf04>;
+		always-on;
+		compatible = "arm,armv8-timer", "arm,armv7-timer";
+	};
+
+	// virtio serial
+	virtio_mmio@a003a00 {
+		dma-coherent;
+		interrupt-parent = <0x01>;
+		interrupts = <0x00 0x2d 0x01>;
+		reg = <0x00 0xa003a00 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	// virtio-blk
+	virtio_mmio@a003e00 {
+		dma-coherent;
+		interrupt-parent = <0x01>;
+		interrupts = <0x00 0x2f 0x01>;
+		reg = <0x00 0xa003e00 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	chosen {
+		bootargs = "earlycon console=hvc0 root=/dev/vda rw";
+		stdout-path = "/virtio_mmio@a003a00";
+	};
+};

--- a/platform/aarch64/qemu-gicv3/image/dts/zone0.dts
+++ b/platform/aarch64/qemu-gicv3/image/dts/zone0.dts
@@ -50,7 +50,7 @@
 		reg = <0x0 0x50000000 0x0 0x70000000>;
 	};
 
-	intc@80000000 {
+	intc@8000000 {
 		phandle = <0x01>;
 		interrupts = <0x01 0x09 0x04>;
 		reg = <0x00 0x8000000 0x00 0x10000 0x00 0x80a0000 0x00 0xf60000>;
@@ -347,7 +347,6 @@
 
 	chosen {
 		bootargs = "clk_ignore_unused earlycon console=ttyAMA0 root=/dev/vda iomem=relaxed rw";
-        // bootargs = "root=/dev/vda mem=768M";
 		stdout-path = "/pl011@9000000";
 	};
 

--- a/platform/aarch64/qemu-gicv3/image/dts/zone1-linux.dts
+++ b/platform/aarch64/qemu-gicv3/image/dts/zone1-linux.dts
@@ -37,7 +37,7 @@
 		reg = <0x0 0x50000000 0x0 0x30000000>;
 	};
 
-	gic@80000000 {
+	gic@8000000 {
 		compatible = "arm,gic-v3";
 		#interrupt-cells = <0x03>;
 		interrupt-controller;
@@ -126,8 +126,6 @@
 
 	chosen {
 		bootargs = "earlycon console=hvc0 root=/dev/vda rw";
-        // bootargs = "root=/dev/vda mem=768M";
 		stdout-path = "/virtio_mmio@a003800";
 	};
-
 };

--- a/platform/aarch64/qemu-gicv3/image/dts/zone1-ruxos.dts
+++ b/platform/aarch64/qemu-gicv3/image/dts/zone1-ruxos.dts
@@ -68,7 +68,7 @@
 		interrupt-affinity = <0x03 0x04>;
 	};
 
-	gic@80000000 {
+	gic@8000000 {
 		compatible = "arm,gic-v3";
 		#interrupt-cells = <0x03>;
 		interrupt-controller;


### PR DESCRIPTION
This PR includes the following fixes and enhancements for `aarch64/qemu-gicv2` and `aarch64/qemu-gicv3`:

- Corrects memory size and adds reserved memory regions in `platform/aarch64/qemu-gicv2/image/dts/zone0.dts`.
- Fixes interrupt controller addresses in the device tree for `aarch64/qemu-gicv3`.
- Adds configuration files for zone1-linux under `aarch64/qemu-gicv2`.
