### PR TITLE
docs: add Dayu200 in supported boards

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -67,6 +67,7 @@ hvisor 是一个用 Rust 实现的 Type-1 裸机虚拟机监控器，采用分�
 - [x] Forlinx OK6254-C
 - [x] Phytium Pi
 - [x] Jetson Orin
+- [x] Dayu200
 
 ### riscv64
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ hvisor is a Type-1 bare-metal virtual machine monitor implemented in Rust, featu
 - [x] Forlinx OK6254-C
 - [x] Phytium Pi
 - [x] Jetson Orin
+- [x] Dayu200
 
 ### riscv64
 


### PR DESCRIPTION
## Summary

- Add `Dayu200` (based on RK3568) to supported boards.
- Both `README.md` and `README-zh.md` have been modified. 

## Motivation

This updates the list of supported boards to match the current state of hvisor.

## Verification

No source code has been modified.

## Risks and Limitations

This is a documentation-only change with no expected runtime or ABI impact.