### PR TITLE
perf: cache per-CPU slot pointer in per-arch registers and drop the percpu crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > ⚠️ Please update this file for any changes to the hvisor project along with your name and GitHub profile link under the CURRENT section.
 
+## CURRENT - next release
+
+- [refactor] **all archs**: Cache the per-CPU slot pointer in an architecture register (`TPIDR_EL2` / `IA32_GS_BASE` / root CSR `SAVE0` / `sscratch`) so `this_cpu_id()`/`this_cpu_data()` stop re-deriving it on every access, and remove the dead `percpu` crate with its `.percpu` link-time sections (23 boards). ([agicy](https://github.com/agicy))
+
 ## CURRENT - v0.6
 
 - [feature] **PCIe/virtio**: Add emulated virtio PCI device support. ([PR #287](https://github.com/syswonder/hvisor/pull/287), [ZZJJWarth](https://github.com/ZZJJWarth))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,6 @@ dependencies = [
  "log",
  "loongArch64",
  "numeric-enum-macro",
- "percpu",
  "psci",
  "qemu-exit",
  "raw-cpuid",
@@ -246,29 +245,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "percpu"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e56c0c558952222967b592899f98765b48590e7bd7403bfd7075f73afc6ed6"
-dependencies = [
- "cfg-if",
- "percpu_macros",
- "spin 0.9.8",
- "x86",
-]
-
-[[package]]
-name = "percpu_macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9f4cc54a2e471ff72f1499461ba381ad4eae9cbd60d29c258545b995e406e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -501,9 +477,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ cortex-a = "8.1.1"
 cfg-if = "1.0"
 bitvec = { version="1.0.1", default-features = false, features = ["atomic", "alloc"] }
 heapless = { version = "0.8.0 "}
-percpu = { package = "percpu", version="0.2", features=["arm-el2"]}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "9.4.0"

--- a/platform/aarch64/dayu200/linker.ld
+++ b/platform/aarch64/dayu200/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x40400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -42,17 +40,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/imx8mp/linker.ld
+++ b/platform/aarch64/imx8mp/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x40400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/jeston-orin/linker.ld
+++ b/platform/aarch64/jeston-orin/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x81000000;
-CPU_NUM = 6;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/ok6254-c/linker.ld
+++ b/platform/aarch64/ok6254-c/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/phytium-pi/linker.ld
+++ b/platform/aarch64/phytium-pi/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x90100000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/qemu-gicv2/linker.ld
+++ b/platform/aarch64/qemu-gicv2/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x40400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/qemu-gicv3/linker.ld
+++ b/platform/aarch64/qemu-gicv3/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x40400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/rk3568/linker.ld
+++ b/platform/aarch64/rk3568/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x60080000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -42,17 +40,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/aarch64/rk3588/linker.ld
+++ b/platform/aarch64/rk3588/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x500000;
-CPU_NUM = 8;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -43,17 +41,6 @@ SECTIONS
         *(.sbss .sbss.*)
     }
     
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
-
     . = ALIGN(4K);
     ebss = .;
     ekernel = .;

--- a/platform/aarch64/sysoul_x3300-scmi/linker.ld
+++ b/platform/aarch64/sysoul_x3300-scmi/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x500000;
-CPU_NUM = 8;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -43,17 +41,6 @@ SECTIONS
         *(.sbss .sbss.*)
     }
     
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
-
     . = ALIGN(4K);
     ebss = .;
     ekernel = .;

--- a/platform/aarch64/sysoul_x3300/linker.ld
+++ b/platform/aarch64/sysoul_x3300/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x500000;
-CPU_NUM = 8;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -43,17 +41,6 @@ SECTIONS
         *(.sbss .sbss.*)
     }
     
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
-
     . = ALIGN(4K);
     ebss = .;
     ekernel = .;

--- a/platform/aarch64/zcu102/linker.ld
+++ b/platform/aarch64/zcu102/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x40400000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -37,17 +35,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/loongarch64/ls3a5000/linker.ld
+++ b/platform/loongarch64/ls3a5000/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x90000001f0000000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -46,17 +44,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/loongarch64/ls3a6000/linker.ld
+++ b/platform/loongarch64/ls3a6000/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x90000001f0000000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -46,17 +44,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/hifive-premier-p550/linker.ld
+++ b/platform/riscv64/hifive-premier-p550/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80200000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/k3-com260/linker.ld
+++ b/platform/riscv64/k3-com260/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x102200000;
-CPU_NUM = 8;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/megrez/linker.ld
+++ b/platform/riscv64/megrez/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80200000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/qemu-aia/linker.ld
+++ b/platform/riscv64/qemu-aia/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80200000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/qemu-plic/linker.ld
+++ b/platform/riscv64/qemu-plic/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80200000;
-CPU_NUM = 4;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/riscv64/ur-dp1000/linker.ld
+++ b/platform/riscv64/ur-dp1000/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0x80200000;
-CPU_NUM = 8;
-
 
 SECTIONS
 {
@@ -38,17 +36,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/x86_64/ecx-2300f-peg/linker.ld
+++ b/platform/x86_64/ecx-2300f-peg/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0xffffff8000200000;
-CPU_NUM = 16;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -41,17 +39,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/x86_64/nuc14mnk/linker.ld
+++ b/platform/x86_64/nuc14mnk/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0xffffff8000200000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -41,17 +39,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/platform/x86_64/qemu/linker.ld
+++ b/platform/x86_64/qemu/linker.ld
@@ -1,7 +1,5 @@
 ENTRY(arch_entry)
 BASE_ADDRESS = 0xffffff8000200000;
-CPU_NUM = 4;
-
 SECTIONS
 {
     . = BASE_ADDRESS;
@@ -41,17 +39,6 @@ SECTIONS
         *(.bss .bss.*)
         *(.sbss .sbss.*)
     }
-
-    . = ALIGN(4K);
-    _percpu_start = .;
-    _percpu_end = _percpu_start + SIZEOF(.percpu);
-    .percpu 0x0 (NOLOAD) : AT(_percpu_start) {
-        _percpu_load_start = .;
-        *(.percpu .percpu.*)
-        _percpu_load_end = .;
-        . = _percpu_load_start + ALIGN(64) * CPU_NUM;
-    }
-    . = _percpu_end;
 
     . = ALIGN(4K);
     ebss = .;

--- a/src/arch/aarch64/cpu.rs
+++ b/src/arch/aarch64/cpu.rs
@@ -14,7 +14,10 @@
 // Authors:
 //
 use crate::{
-    arch::{mm::new_s2_memory_set, sysreg::write_sysreg},
+    arch::{
+        mm::new_s2_memory_set,
+        sysreg::{read_sysreg, write_sysreg},
+    },
     consts::{MAX_CPU_NUM, PAGE_SIZE, PER_CPU_ARRAY_PTR, PER_CPU_SIZE},
     cpu_data::{this_cpu_data, VcpuState},
     memory::{
@@ -24,9 +27,7 @@ use crate::{
     platform::BOARD_MPIDR_MAPPINGS,
     zone::find_zone,
 };
-use aarch64_cpu::registers::{
-    Readable, Writeable, ELR_EL2, HCR_EL2, MPIDR_EL1, SCTLR_EL1, SPSR_EL2, VTCR_EL2,
-};
+use aarch64_cpu::registers::{Writeable, ELR_EL2, HCR_EL2, SCTLR_EL1, SPSR_EL2, VTCR_EL2};
 use core::ptr::addr_of;
 
 use super::{
@@ -263,12 +264,25 @@ pub fn cpuid_to_mpidr_affinity(cpuid: u64) -> (u64, u64, u64, u64) {
 }
 
 pub fn this_cpu_id() -> usize {
-    mpidr_to_cpuid(MPIDR_EL1.get()) as _
+    // TPIDR_EL2 caches the PerCpu slot base (written once per CPU in
+    // PerCpu::new); the id sits at slot offset 0, so this is a register read
+    // plus one load - no MPIDR_EL1 read and no BOARD_MPIDR_MAPPINGS scan.
+    this_cpu_data().id
 }
 
-pub fn store_cpu_pointer_to_reg(_pointer: usize) {
-    // println!("aarch64 doesn't support store cpu pointer to reg, pointer: {:#x}", pointer);
-    return;
+/// Cache the PerCpu slot base of the current CPU in TPIDR_EL2.
+///
+/// TPIDR_EL2 is EL2-private and hvisor never lets a guest touch EL2 state, so
+/// the value survives VM exits without any save/restore. (EL0/EL1 TPIDR_* are
+/// only ever zeroed for a fresh guest in `reset_vm_regs`.)
+pub fn set_this_cpu_pointer(slot_base: usize) {
+    write_sysreg!(TPIDR_EL2, slot_base as u64);
+}
+
+/// PerCpu slot base of the current CPU, cached in TPIDR_EL2 by
+/// `set_this_cpu_pointer` at `PerCpu::new` time.
+pub fn this_cpu_pointer() -> usize {
+    read_sysreg!(TPIDR_EL2) as usize
 }
 
 pub fn get_target_cpu(_irq: usize, zone_id: usize) -> usize {

--- a/src/arch/aarch64/trap.rs
+++ b/src/arch/aarch64/trap.rs
@@ -108,8 +108,6 @@ pub enum TrapReturn {
 
 /*From hyp_vec->handle_vmexit x0:guest regs x1:exit_reason sp =stack_top-32*8*/
 pub fn arch_handle_exit(regs: &mut GeneralRegisters) -> ! {
-    let mpidr = MPIDR_EL1.get();
-    let _cpu_id = mpidr_to_cpuid(mpidr);
     trace!("cpu exit, exit_reson:{:#x?}", regs.exit_reason);
     match regs.exit_reason as u64 {
         ExceptionType::EXIT_REASON_EL1_IRQ | ExceptionType::EXIT_REASON_EL1_AARCH32_IRQ => {

--- a/src/arch/loongarch64/cpu.rs
+++ b/src/arch/loongarch64/cpu.rs
@@ -17,13 +17,13 @@
 use super::ipi::*;
 use super::zone::ZoneContext;
 use crate::arch::zone::disable_hwi_through;
-use crate::cpu_data::{this_cpu_data, VcpuState};
+use crate::cpu_data::{this_cpu_data, PerCpu, VcpuState};
 use crate::zone::find_zone;
 use core::arch::asm;
 use core::fmt::{self, Debug, Formatter};
+use loongArch64::register::crmd;
 use loongArch64::register::crmd::Crmd;
 use loongArch64::register::pgdl;
-use loongArch64::register::{cpuid, crmd};
 
 use crate::{
     consts::{MAX_CPU_NUM, PER_CPU_ARRAY_PTR, PER_CPU_SIZE},
@@ -142,7 +142,10 @@ impl ArchCpu {
 }
 
 pub fn this_cpu_id() -> usize {
-    cpuid::read().core_id()
+    // SAVE0 caches the PerCpu slot base (written once per core in
+    // PerCpu::new); the id sits at slot offset 0. cpuid::read() (CSR 0x20)
+    // stays available for code that wants the raw core id.
+    unsafe { (*(this_cpu_pointer() as *const PerCpu)).id }
 }
 
 pub fn cpu_start(cpuid: usize, start_addr: usize, opaque: usize) {
@@ -157,9 +160,37 @@ pub fn cpu_start(cpuid: usize, start_addr: usize, opaque: usize) {
     ipi_write_action_percore(cpuid, SMP_BOOT_CPU);
 }
 
-pub fn store_cpu_pointer_to_reg(pointer: usize) {
-    // println!("loongarch64 doesn't support store cpu pointer to reg, pointer: {:#x}", pointer);
-    return;
+/// Free root CSR used to cache the PerCpu slot base of the current core.
+///
+/// CSR 0x21 (PRCFG1) is read-only and SAVE3/SAVE4 are the active trap
+/// handoff (run/idle write the ctx/stack pointers), so the root SAVE0 is
+/// the pragmatic free slot. Guest-state SAVE0 lives in the separate GCSR
+/// file (trap.rs gcsrrd/gcsrwr) and is unaffected.
+const CSR_SAVE0: usize = 0x30;
+
+/// Cache the PerCpu slot base of the current core in root CSR SAVE0.
+pub fn set_this_cpu_pointer(slot_base: usize) {
+    unsafe {
+        asm!(
+            "csrwr {}, {LOONGARCH_CSR_SAVE0}",
+            in(reg) slot_base,
+            LOONGARCH_CSR_SAVE0 = const CSR_SAVE0,
+        );
+    }
+}
+
+/// PerCpu slot base of the current core, cached in SAVE0 by
+/// `set_this_cpu_pointer` at `PerCpu::new` time.
+pub fn this_cpu_pointer() -> usize {
+    let ptr: usize;
+    unsafe {
+        asm!(
+            "csrrd {}, {LOONGARCH_CSR_SAVE0}",
+            out(reg) ptr,
+            LOONGARCH_CSR_SAVE0 = const CSR_SAVE0,
+        );
+    }
+    ptr
 }
 
 pub fn get_target_cpu(irq: usize, zone_id: usize) -> usize {

--- a/src/arch/riscv64/cpu.rs
+++ b/src/arch/riscv64/cpu.rs
@@ -14,7 +14,7 @@
 // Authors:
 //
 use super::csr::*;
-use crate::cpu_data::{this_cpu_data, VcpuState};
+use crate::cpu_data::{this_cpu_data, PerCpu, VcpuState};
 use crate::platform::{BOARD_HARTID_MAP, BOARD_NCPUS};
 use crate::{
     arch::mm::new_s2_memory_set,
@@ -275,6 +275,12 @@ impl ArchCpu {
     }
 }
 
+// CSR_SSCRATCH caches the per-pCPU scheduling-context pointer of this hart:
+// the `ArchCpu` of this pCPU's PerCpu slot (guest registers live in
+// `ArchCpu.x` at offset 0, which trap.S reaches by swapping via x31/sscratch,
+// so the cached value must keep being `&slot.arch_cpu`). In a future N:M
+// vCPU schedule this pointer is updated at vCPU switch points instead of
+// staying fixed per boot.
 fn this_cpu_arch() -> &'static mut ArchCpu {
     let sscratch = read_csr!(CSR_SSCRATCH);
     if sscratch == 0 {
@@ -286,6 +292,14 @@ fn this_cpu_arch() -> &'static mut ArchCpu {
 /// Get the logical cpu_id 0..BOARD_NCPUS.
 pub fn this_cpu_id() -> usize {
     this_cpu_arch().get_cpuid()
+}
+
+/// PerCpu slot base of the current hart: the sscratch-cached `&ArchCpu` minus
+/// the `arch_cpu` field offset (container_of). Kept as the sum of a csrr and
+/// a constant subtraction so this_cpu_data() costs no id lookup or table scan.
+pub fn this_cpu_pointer() -> usize {
+    let arch_offset = core::mem::offset_of!(PerCpu, arch_cpu);
+    this_cpu_arch() as *const _ as usize - arch_offset
 }
 
 pub fn hartid_to_cpuid(hartid: usize) -> usize {
@@ -301,11 +315,16 @@ pub fn cpu_start(cpuid: usize, start_addr: usize, opaque: usize) {
     }
 }
 
-pub fn store_cpu_pointer_to_reg(pointer: usize) {
-    // Store the pointer to the current CPU's ArchCpu structure in CSR_SSCRATCH
-    write_csr!(CSR_SSCRATCH, pointer);
-    // println!("Stored CPU pointer to CSR_SSCRATCH: {:#x}", pointer);
-    return;
+/// Cache the PerCpu slot base of the current hart in CSR_SSCRATCH.
+///
+/// SSCRATCH must keep pointing at this CPU's `ArchCpu` (trap.S constraint),
+/// so the slot base handed in by PerCpu::new is translated to `&arch_cpu`
+/// here; reset_regs() re-writes the same value before every VM entry.
+pub fn set_this_cpu_pointer(slot_base: usize) {
+    write_csr!(
+        CSR_SSCRATCH,
+        slot_base + core::mem::offset_of!(PerCpu, arch_cpu)
+    );
 }
 
 pub fn get_target_cpu(_irq: usize, zone_id: usize) -> usize {

--- a/src/arch/x86_64/cpu.rs
+++ b/src/arch/x86_64/cpu.rs
@@ -30,7 +30,7 @@ use crate::{
         vmx::*,
     },
     consts::{self, core_end, PER_CPU_SIZE},
-    cpu_data::{this_cpu_data, this_zone, VcpuState},
+    cpu_data::{this_cpu_data, this_zone, PerCpu, VcpuState},
     device::iommu,
     device::irqchip::pic::{check_pending_vectors, clear_vectors, ioapic, lapic::VirtLocalApic},
     error::{HvError, HvResult},
@@ -188,7 +188,11 @@ pub struct ArchCpu {
 
 impl ArchCpu {
     pub fn new(cpuid: usize) -> Self {
-        let cpuid = this_cpu_id();
+        // The boot entry hands the raw APIC id in; translate it to the logical
+        // id here. This keeps ArchCpu::new free of this_cpu_id(), whose gs:[0]
+        // read requires GS_BASE to be cached first (set_this_cpu_pointer runs
+        // later in PerCpu::new) - this is the last pre-cache call site.
+        let cpuid = crate::arch::acpi::get_cpu_id(cpuid);
         Self {
             guest_regs: GeneralRegisters::default(),
             host_stack_top: 0,
@@ -565,6 +569,11 @@ impl ArchCpu {
         VmcsHost16::FS_SELECTOR.write(x86::segmentation::fs().bits())?;
         VmcsHost16::GS_SELECTOR.write(x86::segmentation::gs().bits())?;
         VmcsHostNW::FS_BASE.write(Msr::IA32_FS_BASE.read() as _)?;
+        // Timing note: set_this_cpu_pointer() (PerCpu::new) has already cached
+        // this CPU's slot base in IA32_GS_BASE by the time setup_vmcs_host()
+        // runs (run/idle happen after PerCpu::new). The hardware reloads this
+        // snapshot on every VM exit, which keeps gs-relative accesses in host
+        // mode pointing at the right PerCpu slot at all times.
         VmcsHostNW::GS_BASE.write(Msr::IA32_GS_BASE.read() as _)?;
 
         let tr = unsafe { x86::task::tr() };
@@ -633,7 +642,19 @@ impl ArchCpu {
 }
 
 pub fn this_cpu_id() -> usize {
-    crate::arch::acpi::get_cpu_id(this_apic_id())
+    // IA32_GS_BASE caches the PerCpu slot base (set once per CPU by
+    // set_this_cpu_pointer in PerCpu::new); the id sits at slot offset 0, so
+    // this is a single gs-relative load - no serializing CPUID leaf-1 and no
+    // ACPI lookup. Deliberately no `nomem` option: the asm does read gs:[0].
+    let id: usize;
+    unsafe {
+        asm!(
+            "mov {}, qword ptr gs:[0]",
+            out(reg) id,
+            options(nostack, preserves_flags)
+        );
+    }
+    id
 }
 
 pub fn this_apic_id() -> usize {
@@ -684,9 +705,31 @@ impl Debug for ArchCpu {
     }
 }
 
-pub fn store_cpu_pointer_to_reg(pointer: usize) {
-    // println!("x86_64 doesn't support store cpu pointer to reg, pointer: {:#x}", pointer);
-    return;
+/// Cache the PerCpu slot base of the current CPU in the IA32_GS_BASE MSR.
+///
+/// setup_vmcs_host snapshots the MSR into the VMCS host-state field (0x6C08)
+/// before every VM launch, so the hardware reloads GS_BASE on each VM exit;
+/// the guest GS_BASE is a separate VMCS guest-state field (0x6810) whose
+/// semantics and MSR interception policy are unchanged.
+pub fn set_this_cpu_pointer(slot_base: usize) {
+    unsafe { Msr::IA32_GS_BASE.write(slot_base as u64) }
+}
+
+/// PerCpu slot base of the current CPU. GS_BASE itself holds the base; the
+/// slot's `self_ptr` (written by PerCpu::new) is materialized in memory so a
+/// gs-relative load can recover it without a slow MSR read.
+#[inline(always)]
+pub fn this_cpu_pointer() -> usize {
+    let ptr: usize;
+    unsafe {
+        asm!(
+            "mov {}, qword ptr gs:[{}]",
+            out(reg) ptr,
+            const core::mem::offset_of!(PerCpu, self_ptr),
+            options(nostack, preserves_flags)
+        );
+    }
+    ptr
 }
 
 pub fn get_target_cpu(irq: usize, zone_id: usize) -> usize {

--- a/src/cpu_data.rs
+++ b/src/cpu_data.rs
@@ -16,7 +16,7 @@
 use alloc::sync::Arc;
 use spin::Mutex;
 
-use crate::arch::cpu::{store_cpu_pointer_to_reg, this_cpu_id, ArchCpu};
+use crate::arch::cpu::{set_this_cpu_pointer, this_cpu_id, this_cpu_pointer, ArchCpu};
 use crate::consts::{INVALID_ADDRESS, PER_CPU_ARRAY_PTR, PER_CPU_SIZE};
 use crate::memory::addr::VirtAddr;
 use crate::zone::Zone;
@@ -110,6 +110,10 @@ pub struct PerCpu {
     pub zone: Option<Arc<Zone>>,
     pub ctrl_lock: Mutex<()>,
     pub boot_cpu: bool,
+    /// Slot base address of this PerCpu. Written once by `PerCpu::new`; x86_64
+    /// materializes it here because gs-segment accesses need the pointer in
+    /// memory, other architectures ignore it and read the register cache.
+    pub self_ptr: usize,
     // percpu stack
 }
 
@@ -128,20 +132,13 @@ impl PerCpu {
                 zone: None,
                 ctrl_lock: Mutex::new(()),
                 boot_cpu: false,
+                self_ptr: ret as usize,
             })
         };
-        unsafe {
-            let pointer = &ret.as_mut().unwrap().arch_cpu as *const _ as usize;
-            store_cpu_pointer_to_reg(pointer);
-        }
-        // #[cfg(target_arch = "riscv64")]
-        // {
-        //     use crate::arch::csr::{write_csr, CSR_SSCRATCH};
-        //     write_csr!(
-        //         CSR_SSCRATCH,
-        //         &ret.as_mut().unwrap().arch_cpu as *const _ as usize
-        //     ); //arch cpu pointer
-        // }
+        // Each CPU caches its own PerCpu slot base in the architecture register
+        // backing this_cpu_pointer()/this_cpu_id(). All later per-CPU accesses
+        // on this core read that cache instead of re-deriving the slot address.
+        set_this_cpu_pointer(ret as usize);
         unsafe { ret.as_mut().unwrap() }
     }
 
@@ -171,8 +168,9 @@ pub fn get_cpu_data<'a>(cpu_id: usize) -> &'a mut PerCpu {
 }
 
 pub fn this_cpu_data<'a>() -> &'a mut PerCpu {
-    // Note: this_cpu_id() should return logical cpu_id 0..BOARD_NCPUS
-    get_cpu_data(this_cpu_id())
+    // Slot base is cached per CPU in an architecture register at PerCpu::new
+    // time, so this is a 1-2 instruction read with no CPU-id lookup involved.
+    unsafe { &mut *(this_cpu_pointer() as *mut PerCpu) }
 }
 
 #[allow(unused)]

--- a/src/cpu_data.rs
+++ b/src/cpu_data.rs
@@ -13,6 +13,42 @@
 //
 // Authors:
 //
+// Per-CPU data model
+// ------------------
+// Each physical CPU owns one PerCpu slot of PER_CPU_SIZE bytes starting at
+// PER_CPU_ARRAY_PTR + cpuid * PER_CPU_SIZE; the per-CPU stack sits above the
+// slot. `id` is deliberately the first field: the per-arch register cache
+// reads the id back from slot offset 0.
+//
+// `PerCpu::new` caches the slot base once per CPU in an architecture register
+// (also materialized in `self_ptr` on x86_64, where a gs-relative load needs
+// the pointer in memory). `this_cpu_data()`/`this_cpu_id()` are then a 1-2
+// instruction read instead of a CPU-id lookup plus table scan:
+//
+//   | arch        | register       | guest can corrupt it?                  |
+//   |-------------|----------------|----------------------------------------|
+//   | aarch64     | TPIDR_EL2      | no - EL2-private                       |
+//   | riscv64     | CSR_SSCRATCH   | no - HS level, guest uses VSSCRATCH    |
+//   | x86_64      | IA32_GS_BASE   | no - VMCS host-state reloads per exit  |
+//   | loongarch64 | root CSR SAVE0 | no - root CSR, guest GCSR file separate|
+//
+// Safety invariants
+// -----------------
+// 1. The register is written only in `PerCpu::new`. Log records (logging.rs
+//    routes every record through this_cpu_data().id) can only fire after the
+//    logger is installed in `primary_init_early`, which every CPU reaches
+//    only after `PerCpu::new` (ENTERED_CPUS gate), so no core ever reads the
+//    cache before writing it. `println!` does not go through the logger.
+// 2. riscv64: sscratch must keep pointing at `&PerCpu.arch_cpu` because
+//    trap.S swaps x31/sscratch to reach guest registers at ArchCpu offset 0.
+//    set_this_cpu_pointer() takes the slot base and adds the field offset, so
+//    this invariant never depends on callers.
+// 3. x86_64: setup_vmcs_host snapshots IA32_GS_BASE into the VMCS host-state
+//    field on every run/idle, i.e. strictly after PerCpu::new on the same
+//    CPU, so hardware reloads the cached base on each VM exit.
+// 4. loongarch64: SAVE3/SAVE4 stay reserved for the trap handoff; SAVE0 is
+//    per-core root state and the guest's SAVE0 lives in the GCSR file.
+//
 use alloc::sync::Arc;
 use spin::Mutex;
 

--- a/src/device/irqchip/ls7a2000/mod.rs
+++ b/src/device/irqchip/ls7a2000/mod.rs
@@ -108,13 +108,19 @@ const INT_TIMER: usize = 11;
 const INT_IPI: usize = 12;
 
 /// Per-pCPU software HWI bitmap, serialized with GINTC VIP updates.
-#[percpu::def_percpu]
-static GUEST_HWI_ASSERTED: Mutex<u32> = Mutex::new(0);
+/// Indexed by logical CPU id; repr-aligned so adjacent states do not share
+/// cache lines (same 64-byte stride the percpu crate's `.percpu` section
+/// used). Only ever accessed remotely (by target CPU id).
+#[repr(align(64))]
+struct GuestHwiState(Mutex<u32>);
+
+static GUEST_HWI_ASSERTED: [GuestHwiState; MAX_CPU_NUM] =
+    [const { GuestHwiState(Mutex::new(0)) }; MAX_CPU_NUM];
 
 // The caller ensures the cpu_id is valid.
 #[inline(always)]
 fn get_guest_hwi_state(cpu: usize) -> &'static Mutex<u32> {
-    unsafe { GUEST_HWI_ASSERTED.remote_ref_raw(cpu) }
+    &GUEST_HWI_ASSERTED[cpu].0
 }
 
 fn sync_guest_irqs_for_cpu(cpu: usize, update: impl FnOnce(&mut u32) -> bool) -> bool {

--- a/src/event.rs
+++ b/src/event.rs
@@ -41,13 +41,21 @@ pub const IPI_EVENT_VIRTIO_PCI_CONFIG: usize = 7;
 pub const IPI_EVENT_VIRTIO_PCI_DATA: usize = 8;
 pub const IPI_EVENT_VIRTIO_PCI_DONE: usize = 9;
 
-#[percpu::def_percpu]
-static PERCPU_EVENTS: Mutex<VecDeque<usize>> = Mutex::new(VecDeque::new());
+/// Per-CPU event queue indexed by logical CPU id. Repr-aligned so adjacent
+/// queues do not share cache lines (same 64-byte stride the percpu crate's
+/// `.percpu` section used). This is a plain array now: the queues are only
+/// ever accessed remotely (by target CPU id), so no per-CPU register or
+/// link-time section machinery is needed.
+#[repr(align(64))]
+struct EventQueue(Mutex<VecDeque<usize>>);
+
+static PERCPU_EVENTS: [EventQueue; MAX_CPU_NUM] =
+    [const { EventQueue(Mutex::new(VecDeque::new())) }; MAX_CPU_NUM];
 
 // The caller ensures the cpu_id is valid
 #[inline(always)]
 fn get_percpu_events(cpu: usize) -> &'static Mutex<VecDeque<usize>> {
-    unsafe { PERCPU_EVENTS.remote_ref_raw(cpu) }
+    &PERCPU_EVENTS[cpu].0
 }
 
 /// Enqueue an event and report whether the target queue was previously empty.

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,14 +196,15 @@ fn rust_main(cpuid: usize, host_dtb: usize) {
     if MASTER_CPU.load(Ordering::Acquire) == -1 {
         MASTER_CPU.store(cpuid as i32, Ordering::Release);
         is_primary = true;
-        percpu::init();
         memory::heap::init();
         memory::heap::test();
         arch::time::init_timebase();
         arch_post_heap_init(host_dtb);
     }
-    percpu::init_percpu_reg(cpuid);
 
+    // PerCpu::new caches the per-CPU slot base in the architecture register
+    // backing this_cpu_pointer()/this_cpu_id(); nothing else needs a
+    // per-CPU register setup at boot.
     let cpu = PerCpu::new(cpuid);
 
     println!(


### PR DESCRIPTION
## Summary

Cache each physical CPU's PerCpu slot base in a per-arch privileged register so `this_cpu_id()` / `this_cpu_data()` become a register read + load instead of a CPU-id lookup plus table scan:

- `aarch64`: `TPIDR_EL2`
- `x86_64`: `IA32_GS_BASE`
- `riscv64`: `CSR_SSCRATCH` (this is the original one, NOT changed)
- `loongarch64`: `root CSR SAVE0`

Also removes the now-unnecessary percpu crate: its only two users were remote-indexed statics, now replaced by plain `MAX_CPU_NUM` arrays with `repr(align(64))`, deleting the `.percpu` link-time sections from all boards. `ArchCpu::new` (x86_64) is unshackled from the pre-cache `this_cpu_id()` cycle, and a dead per-VM-exit `MPIDR_EL1` read + table scan is dropped from the aarch64 exit path.

## Motivation

CPU-local access sits on every hot path: each log record, external-IRQ dispatch, IPI send, and the event loop. Before this change:

- `x86_64` paid a serializing CPUID leaf-1 + ACPI lookup per call;
- `aarch64` read `MPIDR_EL1` and resolved the mapping per call;
- `loongarch64` re-read `CPUNUM` and re-derived the slot every time.

The slot base is a boot-time constant per CPU; re-deriving it per access is pure waste. The percpu crate had become dead weight: only its remote-indexed statics were used, so it contributed only link-time sections, per-CPU init calls, and a dependency for two structures that are now plain arrays.

## Verification

- Builds: make release for aarch64, riscv64, loongarch64, x86_64.
- QEMU aarch64 microbenchmark (CNTPCT, single core before secondary wakeup, 2M calls * 5 rounds, `dev` vs this branch on identical environment):
  - Disassembly: `this_cpu_id()` = `mrs TPIDR_EL2` + `ldr` (2 instructions) vs. `mrs MPIDR_EL1` + `addressing` (~6-8) before.
  - Net cost per 2M calls vs. empty-loop baseline: `this_cpu_id` +28k cycles (branch) vs +558k cycles (dev), `this_cpu_data().id` +23k vs +645k. About 20–28x reduction is here.

## Risks and Limitations

1. New boot invariant: `this_cpu_id()` / `this_cpu_data()` are valid only after PerCpu::new has written the register cache on that CPU. All current paths are safe via the `ENTERED_CPUS` barrier. But any future `pre-PerCpu::new` log/panic path would crash where the old code returned a hardware-derived id. riscv64 already lived under this rule.
2. x86_64 correctness relies on each VMCS host-state `GS_BASE` snapshot being taken by the pCPU that owns that VMCS (structurally guaranteed today: one VMCS per PerCpu slot); cross-pCPU VMCS reuse would require re-snapshotting.
3. loongarch64 `SAVE0` was chosen as a free root CSR after auditing `SAVE3`/`SAVE4` (trap handoff) and the `GCSR` file (guest state); firmware sharing root `SAVE0` would conflict.
4. aarch64 assumes `TPIDR_EL2` is untouched by EL3 firmware across `PSCI` calls.
5. Perf gain is uneven: largest on x86_64, moderate on aarch64, neutral on riscv64/loongarch64, which mainly gain the unified abstraction and crate removal.

## References

Related: [hvisor-book #71](https://github.com/syswonder/hvisor-book/pull/71).